### PR TITLE
Several fixes (Binder/DRMC deploy fixes, etc.)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ atom_devbox: "no"
 
 atom_worker_setup: "yes"
 atom_worker_service_name: "atom-worker"
+# use old config (atom 2.0.x?) for atom worker (atom-worker.conf, app.yml)
+atom_worker_old_config: "no"
 
 #
 # Misc

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -29,6 +29,7 @@
   args:
     chdir: "{{ atom_path }}"
   become_user: "{{ atom_user }}"
+  environment: "{{ atom_pool_php_envs }}"
 
 - name: "Restart smbd"
   service:

--- a/tasks/basic.yml
+++ b/tasks/basic.yml
@@ -103,3 +103,14 @@
     path: "{{ atom_path }}/sf"
     owner: "{{ atom_user }}"
     group: "{{ atom_group }}"
+
+# Export php pool env vars to the login shell, for CLI tools
+#   (such as ARCHIVEMATICA_SS_USER, required in Binder)
+#   To preserve env vars when doing sudo use -E flag
+#   Example: Instead of: sudo -u www-data php symfony cc   
+#                    do: sudo -E -u www-data php symfony cc  
+- name: "Add config to /etc/profile.d"
+  template:
+    src: "etc/profile.d/atom.sh.j2"
+    dest: "/etc/profile.d/atom.sh"
+

--- a/tasks/basic.yml
+++ b/tasks/basic.yml
@@ -1,31 +1,28 @@
 ---
 
-- name: "Ensure that the necessary directories exist"
+# Some issues with git:
+# - git with become_user set to atom_user fails (keys, permissions)
+#   workaround: use the ansible user (become: no) (temporarily change ownership of the dir. to allow this)
+# - Using depth=1 produces errors when the repo was already cloned on the site directory
+#   workarounds: either rename existing atom_path or do not use depth=1
+
+- name: "Create site directory if it doesn't exist'"
   file:
     path: "{{ atom_path }}"
     state: "directory"
     owner: "{{ atom_user }}"
     group: "{{ atom_group }}"
-  with_items:
-    - "{{ atom_path }}"
-    - "{{ atom_path }}/log"
+    mode: "u=rwx,g=rwx,o=rx"
 
 - name: "Cleanup cache/ directory"
   command: "rm -rf {{ atom_path }}/cache/*"
 
-- name: "Pull new code (depth=1 for production)"
-  git:
-    update: "yes"
-    repo: "{{ atom_repository_url }}"
-    version: "{{ atom_repository_version }}"
-    dest: "{{ atom_path }}"
-    accept_hostkey: "yes"
-    depth: "1"
-  when: "atom_environment_type == 'production'"
-  notify:
-    - "Clear sf_cache"
-    - "Reload php-fpm"
-  become_user: "{{ atom_user }}"
+- name: "Temporarily change ownership of site directory to be able to clone repo"
+  file:
+    path: "{{ atom_path }}"
+    state: "directory"
+    owner: "{{ ansible_ssh_user }}"
+    recurse: yes
 
 - name: "Pull new code"
   git:
@@ -34,11 +31,26 @@
     version: "{{ atom_repository_version }}"
     dest: "{{ atom_path }}"
     accept_hostkey: "yes"
-  when: "atom_environment_type == 'development'"
   notify:
     - "Clear sf_cache"
     - "Reload php-fpm"
-  become_user: "{{ atom_user }}"
+  become: "no"
+
+- name: "Restore ownership of site directory"
+  file:
+    path: "{{ atom_path }}"
+    state: "directory"
+    owner: "{{ atom_user }}"
+    group: "{{ atom_group }}"
+    recurse: yes
+
+- name: "Create log directory"
+  file:
+    path: "{{ atom_path }}/log"
+    state: "directory"
+    owner: "{{ atom_user }}"
+    group: "{{ atom_group }}"
+    mode: "u=rwx,g=rwx,o=rx"
 
 - name: "Install configuration files"
   template:
@@ -46,6 +58,7 @@
     dest: "{{ item.dest }}"
     owner: "{{ atom_user }}"
     group: "{{ atom_group }}"
+    backup: "yes"
   with_items:
     - src: "atom/config/config.php"
       dest: "{{ atom_path }}/config/config.php"

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -8,11 +8,22 @@
   command: "{{ item.build_cmd }}"
   args:
     chdir: "{{ item.path }}"
-  with_items: "atom_themes"
+  with_items: "{{ atom_themes }}"
+  become_user: "{{ atom_user }}"
 
 #
-# DRMC
+# DRMC/Binder
 #
+
+# can't compile Drmc plugin as user www-data
+# http://stackoverflow.com/questions/22152162/npm-cannot-install-dependencies-attempt-to-unlock-something-which-hasnt-been
+
+- name: "Temporarily change ownership of DRMC plugin directory"
+  file:
+    path: "{{ atom_drmc_path }}"
+    state: "directory"
+    owner: "{{ ansible_ssh_user }}"
+    recurse: yes
 
 - name: "Install npm local dependencies"
   npm:
@@ -20,15 +31,27 @@
     state: "latest"
   when:
     "atom_drmc is defined and atom_drmc|bool"
+  become: "no"
 
+# using --force option to ignore Error compiling ../../arDominionPlugin/css/main.less
 - name: "Build DRMC"
-  command: "grunt build"
+  command: "grunt build --force"
   args:
     chdir: "{{ atom_drmc_path }}"
   when: "atom_drmc is defined and atom_drmc|bool"
+  become: "no"
 
 - name: "Build docs"
   command: "make html"
   args:
     chdir: "{{ atom_drmc_path }}/docs"
   when: "atom_drmc is defined and atom_drmc|bool"
+  become: "no"
+
+- name: "Restore ownership of site directory"
+  file:
+    path: "{{ atom_drmc_path }}"
+    state: "directory"
+    owner: "{{ atom_user }}"
+    group: "{{ atom_group }}"
+    recurse: yes

--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -1,11 +1,13 @@
 ---
 
-- name: "Add external repository keys"
+# apt-key with https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+# produces "Failed to validate the SSL certificate" error"
+# https://github.com/nodesource/ansible-nodejs-role/issues/33
+- name: "Add Nodesource apt key"
   apt_key:
-    url: "{{ item }}"
-    state: "present"
-  with_items:
-    - "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
+    id: "68576280"
+    state: present
 
 - name: "Add external repositories"
   apt_repository:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,45 +2,45 @@
 
 - include: "deps.yml"
   tags:
-    - "deps"
+    - "atom-deps"
 
 - include: "php.yml"
   tags:
-    - "php"
+    - "atom-php"
 
 - include: "basic.yml"
   tags:
-    - "basic"
+    - "atom-basic"
 
 - include: "flush.yml"
   become_user: "{{ atom_user }}"
   when: "atom_flush_data is defined and atom_flush_data|bool"
   tags:
-    - "flush"
+    - "atom-flush"
 
 - include: "plugins.yml"
   become_user: "{{ atom_user }}"
   tags:
-    - "plugins"
+    - "atom-plugins"
 
 - include: "search.yml"
   become_user: "{{ atom_user }}"
   when: "atom_populate_index is defined and atom_populate_index|bool"
   tags:
-    - "search"
+    - "atom-search"
 
+# do not build as user www-data due to errors with npm
 - include: "build.yml"
-  become_user: "{{ atom_user }}"
   when: "atom_build_static_assets is defined and atom_build_static_assets|bool"
   tags:
-    - "build"
+    - "atom-build"
 
 - include: "worker.yml"
   when: "atom_worker_setup is defined and atom_worker_setup|bool"
   tags:
-    - "worker"
+    - "atom-worker"
 
 - include: "devbox.yml"
   when: "atom_devbox|bool"
   tags:
-    - "devbox"
+    - "atom-devbox"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -5,6 +5,7 @@
   args:
     chdir: "{{ atom_path }}"
   with_items: "{{ atom_plugins }}"
+  environment: "{{ atom_pool_php_envs }}"
 
 # TODO: arElasticSearchPlugin scripts:
 #       copy files from  plugins/arElasticSearchPlugin/scripts/

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -4,4 +4,8 @@
   command: "php symfony tools:atom-plugins add {{ item }}"
   args:
     chdir: "{{ atom_path }}"
-  with_items: "atom_plugins"
+  with_items: "{{ atom_plugins }}"
+
+# TODO: arElasticSearchPlugin scripts:
+#       copy files from  plugins/arElasticSearchPlugin/scripts/
+#                  to /etc/elasticsearch/scripts/ of the elasticsearch server

--- a/templates/atom/apps/qubit/config/app.yml
+++ b/templates/atom/apps/qubit/config/app.yml
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# Ansible managed file, do not edit directly
 
 all:
 
@@ -27,4 +27,9 @@ all:
   ldap_base_dn: {{ atom_app_ldap_base_dn }}
   ldap_domain_controllers: {{ atom_app_ldap_domain_controllers }}
   ldap_user_group: {{ atom_app_ldap_user_group }}
+{% endif %}
+
+{% if atom_worker_old_config|bool %}
+  # Gearman job server 
+  gearman_job_server: {{ atom_app_gearman_job_server }}
 {% endif %}

--- a/templates/atom/apps/qubit/config/factories.yml
+++ b/templates/atom/apps/qubit/config/factories.yml
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# Ansible managed file, do not edit directly
 # You can find more information about this file on the symfony website:
 # http://www.symfony-project.org/reference/1_4/en/05-Factories
 

--- a/templates/atom/apps/qubit/config/gearman.yml
+++ b/templates/atom/apps/qubit/config/gearman.yml
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# Ansible managed file, do not edit directly
 
 all:
   servers:

--- a/templates/atom/apps/qubit/config/search.yml
+++ b/templates/atom/apps/qubit/config/search.yml
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# Ansible managed file, do not edit directly
 
 all:
 
@@ -38,12 +38,185 @@ all:
           # in some fields as it can make the index very big.
           autocomplete:
             tokenizer: whitespace
-            filter: [lowercase, engram]
+            filter: [lowercase, engram, preserved_asciifolding]
+
+          arabic:
+            tokenizer: standard
+            filter: [lowercase, arabic_stop, preserved_asciifolding]
+          armenian:
+            tokenizer: standard
+            filter: [lowercase, armenian_stop, preserved_asciifolding]
+          basque:
+            tokenizer: standard
+            filter: [lowercase, basque_stop, preserved_asciifolding]
+          brazilian:
+            tokenizer: standard
+            filter: [lowercase, brazilian_stop, preserved_asciifolding]
+          bulgarian:
+            tokenizer: standard
+            filter: [lowercase, bulgarian_stop, preserved_asciifolding]
+          catalan:
+            tokenizer: standard
+            filter: [lowercase, catalan_stop, preserved_asciifolding]
+          czech:
+            tokenizer: standard
+            filter: [lowercase, czech_stop, preserved_asciifolding]
+          danish:
+            tokenizer: standard
+            filter: [lowercase, danish_stop, preserved_asciifolding]
+          dutch:
+            tokenizer: standard
+            filter: [lowercase, dutch_stop, preserved_asciifolding]
+          english:
+            tokenizer: standard
+            filter: [lowercase, english_stop, preserved_asciifolding]
+          finnish:
+            tokenizer: standard
+            filter: [lowercase, finnish_stop, preserved_asciifolding]
+          french:
+            tokenizer: standard
+            filter: [lowercase, french_stop, preserved_asciifolding, french_elision]
+          galician:
+            tokenizer: standard
+            filter: [lowercase, galician_stop, preserved_asciifolding]
+          german:
+            tokenizer: standard
+            filter: [lowercase, german_stop, preserved_asciifolding]
+          greek:
+            tokenizer: standard
+            filter: [lowercase, greek_stop, preserved_asciifolding]
+          hindi:
+            tokenizer: standard
+            filter: [lowercase, hindi_stop, preserved_asciifolding]
+          hungarian:
+            tokenizer: standard
+            filter: [lowercase, hungarian_stop, preserved_asciifolding]
+          indonesian:
+            tokenizer: standard
+            filter: [lowercase, indonesian_stop, preserved_asciifolding]
+          italian:
+            tokenizer: standard
+            filter: [lowercase, italian_stop, preserved_asciifolding]
+          norwegian:
+            tokenizer: standard
+            filter: [lowercase, norwegian_stop, preserved_asciifolding]
+          persian:
+            tokenizer: standard
+            filter: [lowercase, persian_stop, preserved_asciifolding]
+          portuguese:
+            tokenizer: standard
+            filter: [lowercase, portuguese_stop, preserved_asciifolding]
+          romanian:
+            tokenizer: standard
+            filter: [lowercase, romanian_stop, preserved_asciifolding]
+          russian:
+            tokenizer: standard
+            filter: [lowercase, russian_stop, preserved_asciifolding]
+          spanish:
+            tokenizer: standard
+            filter: [lowercase, spanish_stop, preserved_asciifolding]
+          swedish:
+            tokenizer: standard
+            filter: [lowercase, swedish_stop, preserved_asciifolding]
+          turkish:
+            tokenizer: standard
+            filter: [lowercase, turkish_stop, preserved_asciifolding]]
+
         filter:
           engram:
             type: edgeNGram
             min_gram: 3
             max_gram: 10
+          french_elision:
+            type: elision
+            articles: [l, m, t, qu, n, s, j, d, c, jusqu, quoiqu, lorsqu, puisqu]
+          preserved_asciifolding:
+            type: asciifolding
+            preserve_original: true
+
+          # To make 'stopwords' works with other token filters the analyzers can't have
+          # standard type and the 'stopwords' needs to be added as a token filter too
+          arabic_stop:
+            type: stop
+            stopwords: _arabic_
+          armenian_stop:
+            type: stop
+            stopwords: _armenian_
+          basque_stop:
+            type: stop
+            stopwords: _basque_
+          brazilian_stop:
+            type: stop
+            stopwords: _brazilian_
+          bulgarian_stop:
+            type: stop
+            stopwords: _bulgarian_
+          catalan_stop:
+            type: stop
+            stopwords: _catalan_
+          czech_stop:
+            type: stop
+            stopwords: _czech_
+          danish_stop:
+            type: stop
+            stopwords: _danish_
+          dutch_stop:
+            type: stop
+            stopwords: _dutch_
+          english_stop:
+            type: stop
+            stopwords: _english_
+          finnish_stop:
+            type: stop
+            stopwords: _finnish_
+          french_stop:
+            type: stop
+            stopwords: _french_
+          galician_stop:
+            type: stop
+            stopwords: _galician_
+          german_stop:
+            type: stop
+            stopwords: _german_
+          greek_stop:
+            type: stop
+            stopwords: _greek_
+          hindi_stop:
+            type: stop
+            stopwords: _hindi_
+          hungarian_stop:
+            type: stop
+            stopwords: _hungarian_
+          indonesian_stop:
+            type: stop
+            stopwords: _indonesian_
+          italian_stop:
+            type: stop
+            stopwords: _italian_
+          norwegian_stop:
+            type: stop
+            stopwords: _norwegian_
+          persian_stop:
+            type: stop
+            stopwords: _persian_
+          portuguese_stop:
+            type: stop
+            stopwords: _portuguese_
+          romanian_stop:
+            type: stop
+            stopwords: _romanian_
+          russian_stop:
+            type: stop
+            stopwords: _russian_
+          spanish_stop:
+            type: stop
+            stopwords: _spanish_
+          swedish_stop:
+            type: stop
+            stopwords: _swedish_
+          turkish_stop:
+            type: stop
+            stopwords: _turkish_
 
       # Disable dynamic creation of mappings for unmapped types
       mapper:

--- a/templates/atom/apps/qubit/config/settings.yml
+++ b/templates/atom/apps/qubit/config/settings.yml
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# Ansible managed file, do not edit directly
 # You can find more information about this file on the symfony website:
 # http://www.symfony-project.org/reference/1_4/en/04-Settings
 

--- a/templates/atom/config/config.php
+++ b/templates/atom/config/config.php
@@ -1,6 +1,6 @@
 <?php
 
-# {{ ansible_managed }}
+# Ansible managed file, do not edit directly
 
 return array (
   'all' =>

--- a/templates/atom/config/propel.ini
+++ b/templates/atom/config/propel.ini
@@ -1,4 +1,4 @@
-; {{ ansible_managed }}
+; Ansible managed file, do not edit directly
 
 propel.targetPackage       = lib.model
 propel.packageObjectModel  = true

--- a/templates/etc/init/atom-worker.conf
+++ b/templates/etc/init/atom-worker.conf
@@ -14,6 +14,13 @@ post-stop exec sleep 3
 
 env LOCATION={{ atom_path }}
 env LOGFILE={{ atom_path }}/log/worker.log
+# AtoM PHP pool vars 
+{% for key, value in atom_pool_php_envs.iteritems() %}
+{% if value != "" -%}
+    env {{ key }}="{{ value }}"
+{% endif %}
+{% endfor %}
+
 
 setuid {{ atom_user }}
 setgid {{ atom_group }}

--- a/templates/etc/init/atom-worker.conf
+++ b/templates/etc/init/atom-worker.conf
@@ -1,3 +1,4 @@
+# Ansible managed file, do not edit directly
 description "AtoM worker upstart service"
 
 start on startup
@@ -22,6 +23,10 @@ script
   php \
     -d memory_limit=-1 \
     -d error_reporting="E_ALL" \
+{% if atom_worker_old_config|bool %}
+      ${LOCATION}/symfony tools:gearman-worker >> ${LOGFILE} 2>&1
+{% else %}
       ${LOCATION}/symfony jobs:worker >> ${LOGFILE} 2>&1
+{% endif %}
 
 end script

--- a/templates/etc/php/5/fpm/pool.d/atom.conf
+++ b/templates/etc/php/5/fpm/pool.d/atom.conf
@@ -1,4 +1,4 @@
-; {{ ansible_managed }}
+; Ansible managed file, do not edit directly
 [atom]
 
 ; The user running the application

--- a/templates/etc/php/7.0/fpm/pool.d/atom.conf
+++ b/templates/etc/php/7.0/fpm/pool.d/atom.conf
@@ -1,4 +1,4 @@
-; {{ ansible_managed }}
+; Ansible managed file, do not edit directly
 [atom]
 
 ; The user running the application

--- a/templates/etc/profile.d/atom.sh.j2
+++ b/templates/etc/profile.d/atom.sh.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+# this file managed by ansible
+# AtoM environment variables (required by CLI tools)
+{% for key, value in atom_pool_php_envs.iteritems() %}
+{% if value != "" -%}
+    export {{ key }}="{{ value }}"
+{% endif %}
+{% endfor %}

--- a/templates/lib/systemd/system/atom-worker.service
+++ b/templates/lib/systemd/system/atom-worker.service
@@ -16,3 +16,9 @@ Restart=no
 
 #Environment=ATOM_FOO_1=BAR
 #Environment=ATOM_FOO_2=BAR
+# AtoM PHP pool vars 
+{% for key, value in atom_pool_php_envs.iteritems() %}
+{% if value != "" -%}
+    Environment={{ key }}="{{ value }}"
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
- Add option to use old AtoM worker configuration
- Do not use depth=1 when cloning from repository to avoid errors
- Do not use become when cloning from repository to avoid errors
- Do not use become for npm (DRMC) to avoid errors
- Use --force option in grunt build (DRMC) to avoid errors
- Do not use {{ ansible_managed }} in templates to avoid unnecessary
  updating
- Update search.yml template
- Change tag names to "atom-xxxx"
- Fix Nodesource public key retrieval
- Configure environment vars for CLI tasks