### PR TITLE
Add worker logging config to settings.yml

### DIFF
--- a/templates/atom/apps/qubit/config/settings.yml
+++ b/templates/atom/apps/qubit/config/settings.yml
@@ -12,6 +12,10 @@ prod:
     logging_enabled:        true
     cache:                  true
 
+worker:
+  .settings:
+    logging_enabled:        true
+
 dev:
   .settings:
     error_reporting:        <?php echo (E_ALL | E_STRICT)."\n" ?>


### PR DESCRIPTION
Add atom worker logging settings. This is a qa/2.4.x feature, but the change doesn't have effect on previous releases.

Refs: https://projects.artefactual.com/issues/9999#note-21