### PR TITLE
set atom_populate_index to no

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,7 +29,7 @@ atom_worker_old_config: "no"
 #
 
 # Populate search index
-atom_populate_index: "yes"
+atom_populate_index: "no"
 
 # Flush database
 atom_flush_data: "no"


### PR DESCRIPTION
On some occassions, update deployments of standalone/test AtoM instances
have not specified whether to (re-)index or not, and have fallen back
to this default, even if change doesn't require same.