### PR TITLE
Updates for 2.4.1 deployments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,8 @@ atom_themes:
 atom_plugins:
   - "qtSwordPlugin"
 
+atom_gdpr_enabled: "False"
+
 # Default user for tools:purge
 atom_user_email: "demo@example.com"
 atom_user_username: "demo"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -5,6 +5,12 @@
 #    become_user: "{{ atom_user }}"
 #    environment: "{{ atom_pool_php_envs }}"
 
+- name: "Update database"
+  command: "php symfony tools:upgrade-sql -B"
+  args:
+    chdir: "{{ atom_path }}"
+  when:
+    - "(atom_upgrade_sql is defined and atom_upgrade_sql|bool == true)"
 
 - name: "Enable AtoM plug-ins"
   shell: "php symfony tools:atom-plugins add {{ item }}"
@@ -17,7 +23,6 @@
   command: "php symfony tools:run lib/task/tools/addGdprSettings.php"
   args:
     chdir: "{{ atom_path }}"
-  environment: "{{ atom_pool_php_envs }}"
   when: "atom_gdpr_enabled is defined and atom_gdpr_enabled|bool"
 
 

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -12,6 +12,15 @@
     chdir: "{{ atom_path }}"
   with_items: "{{ atom_plugins }}"
 
+
+- name: "Enable AtoM GDPR privacy page"
+  command: "php symfony tools:run lib/task/tools/addGdprSettings.php"
+  args:
+    chdir: "{{ atom_path }}"
+  environment: "{{ atom_pool_php_envs }}"
+  when: "atom_gdpr_enabled is defined and atom_gdpr_enabled|bool"
+
+
 # copy ES plugins to /etc/elasticsearch (assumes ES running on same server) 
 # (copy manually if ES is on a separate backend server)
 - name: "Copy elasticsearch plugins"

--- a/tasks/worker.yml
+++ b/tasks/worker.yml
@@ -104,3 +104,17 @@
     state: "link"
   tags:
     - "fop"
+
+- name: "Allow pdfs to be converted by ImageMagick (Ubuntu 14.04)"
+  lineinfile:
+    path: "/etc/ImageMagick/policy.xml"
+    state: "absent"
+    regexp: 'PDF" />$'
+  when: "ansible_distribution_version | version_compare('14.04', '==')"
+
+- name: "Allow pdfs to be converted by ImageMagick (Ubuntu 16.04)"
+  lineinfile:
+    path: "/etc/ImageMagick-6/policy.xml"
+    state: "absent"
+    regexp: 'PDF" />$'
+  when: "ansible_distribution_version | version_compare('16.04', '>=')"


### PR DESCRIPTION
- Fixes the imagemagick policy.xml file to allow imagemagick to create thumbnails for pdf files
- Adds `atom_gdpr_enabled` var. When enabled, it runs the symfony script that creates the privacy page