### PR TITLE
Atom 2.4.1 updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,8 @@ atom_themes:
 atom_plugins:
   - "qtSwordPlugin"
 
+atom_gdpr_enabled: "False"
+
 # Default user for tools:purge
 atom_user_email: "demo@example.com"
 atom_user_username: "demo"

--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -39,6 +39,7 @@
     - "make"              #
     - "python-pip"        #
     - "python-setuptools" #
+    - "openjdk-8-jre-headless" # Needed by FOP
 
 - name: "Install Sphinx"
   pip:

--- a/tasks/fop.yml
+++ b/tasks/fop.yml
@@ -1,0 +1,55 @@
+---
+
+- name: "Install FOP ( Ubuntu 18.04)"
+  apt:
+    pkg: "fop"
+    state: "latest"
+  when: "ansible_distribution_version | version_compare('18.04', '==')"
+  tags:
+    - "fop"
+
+- name: "Use FOP 2.1 in AtoM 2.3 or newer (Ubuntu 16.04)"
+  set_fact:
+    fop_version: "2.1"
+  tags:
+    - "fop"
+
+- name: "Install Apache FOP: unarchive"
+  unarchive:
+    src: "https://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-{{ fop_version }}-bin.tar.gz"
+    dest: "/usr/share"
+    creates: "/usr/share/fop-{{ fop_version }}"
+    copy: "no"
+    owner: "root"
+    group: "root"
+  when: ( ansible_distribution_version | version_compare('16.04', '==') ) or
+        ( ansible_os_family == "RedHat" )
+  tags:
+    - "fop"
+
+- name: "Install Apache FOP: set up FOP_HOME"
+  lineinfile:
+    dest: "/etc/environment"
+    line: "FOP_HOME=/usr/share/fop-{{ fop_version }}"
+  when: ( ansible_distribution_version | version_compare('16.04', '==') ) or
+        ( ansible_os_family == "RedHat" )
+  tags:
+    - "fop"
+
+- name: "Install Apache FOP: symlink"
+  file:
+    src: "/usr/share/fop-{{ fop_version }}/fop"
+    dest: "/usr/local/bin/fop"
+    state: "link"
+  when: ( ansible_distribution_version | version_compare('16.04', '==') ) or
+        ( ansible_os_family == "RedHat" )
+  tags:
+    - "fop"
+
+- name: "Allow pdfs to be converted by ImageMagick (Ubuntu)"
+  lineinfile:
+    path: "/etc/ImageMagick-6/policy.xml"
+    state: "absent"
+    regexp: 'PDF" />$'
+  when: "ansible_distribution_version | version_compare('16.04', '>=')"
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,13 @@
         - "atom-php"
       when:
         - ansible_os_family == "RedHat"
+
+    - include: "fop.yml"
+      environment:
+        - PATH: "{{ ansible_env.PATH }}:/opt/rh/rh-php{{ php_version }}/root/bin/"
+      tags:
+        - "fop"
+
   when: atom_install_dependencies|bool == true
     
 - name: "Install AtoM site"

--- a/tasks/php-rh.yml
+++ b/tasks/php-rh.yml
@@ -17,6 +17,7 @@
     - "rh-php{{ php_version }}-php-pecl-apcu"
     - "zlib-devel" # needed for memcached
     - "unzip"
+    - "java-1.8.0-openjdk-headless" # needed for fop
 
 - name: "Create /usr/bin/php link"
   file:

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -5,6 +5,12 @@
 #    become_user: "{{ atom_user }}"
 #    environment: "{{ atom_pool_php_envs }}"
 
+- name: "Update database"
+  command: "php symfony tools:upgrade-sql -B"
+  args:
+    chdir: "{{ atom_path }}"
+  when:
+    - "(atom_upgrade_sql is defined and atom_upgrade_sql|bool == true)"
 
 - name: "Enable AtoM plug-ins"
   shell: "php symfony tools:atom-plugins add {{ item }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -12,6 +12,12 @@
     chdir: "{{ atom_path }}"
   with_items: "{{ atom_plugins }}"
 
+- name: "Enable AtoM GDPR privacy page"
+  command: "php symfony tools:run lib/task/tools/addGdprSettings.php"
+  args:
+    chdir: "{{ atom_path }}"
+  when: "atom_gdpr_enabled is defined and atom_gdpr_enabled|bool"
+
 # copy ES plugins to /etc/elasticsearch (assumes ES running on same server) 
 # (copy manually if ES is on a separate backend server)
 - name: "Copy elasticsearch plugins"


### PR DESCRIPTION
- Installs fop as part of the deployment, not only when worker is being configured
- Fixes the imagemagick policy.xml file to allow imagemagick to create thumbnails for pdf files
- Adds atom_gdpr_enabled var. When enabled, it runs the symfony script that creates the privacy page