### PR TITLE
Change session.save_path for Ubuntu

### DIFF
--- a/templates/etc/php/7.0/fpm/pool.d/atom.conf
+++ b/templates/etc/php/7.0/fpm/pool.d/atom.conf
@@ -35,7 +35,11 @@ php_admin_value[display_errors] = off
 php_admin_value[display_startup_errors] = off
 php_admin_value[html_errors] = off
 php_admin_value[session.use_only_cookies] = 0
+{% if ansible_os_family == "Debian" %}
+php_admin_value[session.save_path] = /var/lib/php/sessions
+{% else %}
 php_admin_value[session.save_path] = /tmp
+{% endif %}
 
 ; APC
 php_admin_value[apc.enabled] = 1


### PR DESCRIPTION
- per default /usr/lib/php/sessionclean no longer looks in /tmp as of php 7.0

Also:

- assuming for now php 7.0 and php 7.2 needs are still same (currently templates/etc/php/7.2 -> 7.0)

- not immediately clear how garbage collection is being done on our RedHat / CentOS deployments?
(later Add-Note - ah, found a historical=old reference RH automatic/"built-in" php garbage collection is used, I guess wherever we choose to define it, but "Debian sets very stringent permissions on /var/lib/php5 (1733, owner root, group root) to prevent PHP session hijacking")

- also open to argument of doing garbage collection on Ubuntu differently, but this change to our code seems to make sense if sessionclean is being automatically installed/configured for php7.x-fpm (ala php-common, looks like).