### PR TITLE
Remove deprecated Jinja test syntax, refs #23

### DIFF
--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -8,7 +8,7 @@
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     id: "68576280"
     state: present
-  when: "ansible_distribution_version | version_compare('16.04', '<=')"
+  when: "ansible_distribution_version is version_compare('16.04', '<=')"
 
 - name: "Add external repositories"
   apt_repository:
@@ -16,13 +16,13 @@
     update_cache: "yes"
   with_items:
     - "deb https://deb.nodesource.com/node_5.x {{ ansible_distribution_release }} main"
-  when: "ansible_distribution_version | version_compare('16.04', '<=')"
+  when: "ansible_distribution_version is version_compare('16.04', '<=')"
 
 - name: "Add archivematica/externals-dev PPA (ffmpeg in Ubuntu <= 14.04)"
   apt_repository:
     repo: "ppa:archivematica/externals-dev"
     update_cache: "yes"
-  when: "ansible_distribution_version | version_compare('14.04', '<=')"
+  when: "ansible_distribution_version is version_compare('14.04', '<=')"
 
 - name: "Install AtoM dependencies (Ubuntu <= Xenial/16.04)"
   apt:
@@ -39,7 +39,7 @@
     - "python-pip"        #
     - "python-setuptools" #
     - "openjdk-8-jre-headless" # Needed by FOP
-  when: "ansible_distribution_version | version_compare('16.04', '<=')"
+  when: "ansible_distribution_version is version_compare('16.04', '<=')"
 
 - name: "Install AtoM dependencies (Ubuntu >= Bionic/18.04)"
   apt:
@@ -56,7 +56,7 @@
     - "python-pip"        #
     - "python-setuptools" #
     - "openjdk-8-jre-headless" # Needed by FOP
-  when: "ansible_distribution_version | version_compare('18.04', '>=')"
+  when: "ansible_distribution_version is version_compare('18.04', '>=')"
 
 - name: "Install Sphinx"
   pip:

--- a/tasks/fop.yml
+++ b/tasks/fop.yml
@@ -4,7 +4,7 @@
   apt:
     pkg: "fop"
     state: "latest"
-  when: "ansible_distribution_version | version_compare('18.04', '==')"
+  when: "ansible_distribution_version is version_compare('18.04', '==')"
   tags:
     - "fop"
 
@@ -22,7 +22,7 @@
     copy: "no"
     owner: "root"
     group: "root"
-  when: ( ansible_distribution_version | version_compare('16.04', '==') ) or
+  when: ( ansible_distribution_version is version_compare('16.04', '==') ) or
         ( ansible_os_family == "RedHat" )
   tags:
     - "fop"
@@ -31,7 +31,7 @@
   lineinfile:
     dest: "/etc/environment"
     line: "FOP_HOME=/usr/share/fop-{{ fop_version }}"
-  when: ( ansible_distribution_version | version_compare('16.04', '==') ) or
+  when: ( ansible_distribution_version is version_compare('16.04', '==') ) or
         ( ansible_os_family == "RedHat" )
   tags:
     - "fop"
@@ -41,7 +41,7 @@
     src: "/usr/share/fop-{{ fop_version }}/fop"
     dest: "/usr/local/bin/fop"
     state: "link"
-  when: ( ansible_distribution_version | version_compare('16.04', '==') ) or
+  when: ( ansible_distribution_version is version_compare('16.04', '==') ) or
         ( ansible_os_family == "RedHat" )
   tags:
     - "fop"
@@ -51,5 +51,5 @@
     path: "/etc/ImageMagick-6/policy.xml"
     state: "absent"
     regexp: 'PDF" />$'
-  when: "ansible_distribution_version | version_compare('16.04', '>=')"
+  when: "ansible_distribution_version is version_compare('16.04', '>=')"
 

--- a/tasks/php.yml
+++ b/tasks/php.yml
@@ -14,7 +14,7 @@
   file:
     state: "absent"
     path: "/etc/php{{ php_version }}/fpm/pool.d/www.conf"
-  when: "ansible_distribution_version | version_compare('14.04', '==')"
+  when: "ansible_distribution_version is version_compare('14.04', '==')"
   notify:
     - "Restart PHP service"
 
@@ -22,7 +22,7 @@
   file:
     state: "absent"
     path: "/etc/php/{{ php_version }}/fpm/pool.d/www.conf"
-  when: "ansible_distribution_version | version_compare('16.04', '>=')"
+  when: "ansible_distribution_version is version_compare('16.04', '>=')"
   notify:
     - "Restart PHP service"
 
@@ -30,17 +30,17 @@
   template:
     src: "etc/php{{ php_version }}/fpm/pool.d/atom.conf"
     dest: "/etc/php/{{ php_version }}/fpm/pool.d/atom.conf"
-  when: "ansible_distribution_version | version_compare('14.04', '==')"
+  when: "ansible_distribution_version is version_compare('14.04', '==')"
 
 - name: "Install pool configuration file ( Ubuntu >= 16.04 )"
   template:
     src: "etc/php/{{ php_version }}/fpm/pool.d/atom.conf"
     dest: "/etc/php/{{ php_version }}/fpm/pool.d/atom.conf"
-  when: "ansible_distribution_version | version_compare('16.04', '>=')"
+  when: "ansible_distribution_version is version_compare('16.04', '>=')"
 
 # See https://bugs.launchpad.net/ubuntu/+source/php5/+bug/1272788
 - name: "Fix php5-fpm upstart"
   lineinfile:
     dest: "/etc/init/php5-fpm.conf"
     line: "reload signal USR2"
-  when: "ansible_distribution_version | version_compare('14.04', '==')"
+  when: "ansible_distribution_version is version_compare('14.04', '==')"

--- a/tasks/worker.yml
+++ b/tasks/worker.yml
@@ -41,7 +41,7 @@
     state: "latest"
   when:
     - ansible_distribution == "Ubuntu"
-    - ansible_distribution_version | version_compare('14.04', '<=')
+    - ansible_distribution_version is version_compare('14.04', '<=')
   tags:
     - "fop"
 
@@ -51,10 +51,10 @@
     state: "latest"
   when:
     - ansible_distribution == "Ubuntu"
-    - ansible_distribution_version | version_compare('14.04', '>')
+    - ansible_distribution_version is version_compare('14.04', '>')
   tags:
     - "fop"
- 
+
 - name: "Install OpenJDK 8 (RedHat/Centos)"
   yum:
     name: "java-1.8.0-openjdk-headless"
@@ -64,18 +64,18 @@
   tags:
     - "fop"
 
-- name: "Use FOP 2.1 in AtoM 2.3 or newer (Ubuntu 16.04)" 
+- name: "Use FOP 2.1 in AtoM 2.3 or newer (Ubuntu 16.04)"
   set_fact:
     fop_version: "2.1"
-  when: ( ansible_distribution_version | version_compare('16.04', '>=') ) or
+  when: ( ansible_distribution_version is version_compare('16.04', '>=') ) or
         ( ansible_os_family == "RedHat" )
   tags:
     - "fop"
 
-- name: "Use FOP 1.0 in AtoM 2.2 (Ubuntu 14.04)" 
+- name: "Use FOP 1.0 in AtoM 2.2 (Ubuntu 14.04)"
   set_fact:
     fop_version: "1.0"
-  when: "ansible_distribution_version | version_compare('14.04', '==')"
+  when: "ansible_distribution_version is version_compare('14.04', '==')"
   tags:
     - "fop"
 

--- a/templates/etc/php/5/fpm/pool.d/atom.conf
+++ b/templates/etc/php/5/fpm/pool.d/atom.conf
@@ -43,7 +43,7 @@ php_admin_value[apc.shm_size] = 192M
 php_admin_value[apc.num_files_hint] = 5000
 php_admin_value[apc.stat] = {% if atom_environment_type == 'development' %}1{% else %}0{% endif %}
 
-{% if ansible_distribution_version | version_compare('14.04', '>=') %}
+{% if ansible_distribution_version is version_compare('14.04', '>=') %}
 ; Zend OPcache
 php_admin_value[opcache.enable] = 1
 php_admin_value[opcache.enable_cli] = 0

--- a/templates/etc/php/7.0/fpm/pool.d/atom.conf
+++ b/templates/etc/php/7.0/fpm/pool.d/atom.conf
@@ -47,7 +47,7 @@ php_admin_value[apc.shm_size] = 192M
 php_admin_value[apc.num_files_hint] = 5000
 php_admin_value[apc.stat] = {% if atom_environment_type == 'development' %}1{% else %}0{% endif %}
 
-{% if ansible_distribution_version | version_compare('14.04', '>=') %}
+{% if ansible_distribution_version is version_compare('14.04', '>=') %}
 ; Zend OPcache
 php_admin_value[opcache.enable] = 1
 php_admin_value[opcache.enable_cli] = 0


### PR DESCRIPTION
Using Jinja tests with filter syntax has been deprecated as of Ansible
2.5, see:

https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters