### PR TITLE
Allow deployment of multiple sites on same host

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,6 @@ done elsewhere)
 
 The `-t atom-site` option makes ansible execute only the tasks tagged
 as `atom-site` in the role (i.e., tasks required to deploy a site)
-and skip the tasks that are required only once per host deploy.
+and skip the tasks that are required only once per host deploy. The
+database and user for the new site will also need to be configured in
+the database server if not done already.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,73 @@ template, adding a customized template with the default path and name in your
 playbook structure won't work.  E.g. Changing the "atom/config/config.php"
 to "myatom/config/config.php" will load a template file at that relative
 path in your playbook directory structure.
+
+## Deploy multiple sites on the same host
+
+To deploy multiple AtoM sites on the same host, it is possible to have
+an arrangement as follows:
+
+```
+.
+|-- host_vars
+|   `-- atomhost
+|       |-- vars.yml       => variables common for all sites
+|       |-- ...
+|-- sites
+|   |-- atomsite1.yml      => variables for site1
+|   |-- atomsite2.yml      => variables for site2
+|   |-- ...
+|-- playbook-atom.yml      => AtoM deployment playbook
+|-- ansible.cfg
+|-- hosts
+|-- ... 
+```
+
+Where `atomsite1.yml`, `atomsite2.yml`, ... define role variables that
+need to be different for site1, site2,... 
+
+As a minimum, the variable `atom_path` must be different for each site. 
+The basename of `atom_path` is used to create identifiers that need to be 
+different for each site, such as php pool and worker names (the basename
+is the last component of the path, e.g., if `atom_path` is 
+"/usr/share/nginx/atom" then the basename is "atom")
+
+For example, if deploying AtoM production and test sites, we could 
+define the production site variables in `atomsite1.yml`:
+
+```
+atom_path: "/usr/share/nginx/atom"
+atom_config_db_name: "atom_prod"
+atom_config_db_username: "atomuser_prod"
+atom_config_db_password: "{{ vault_atomuser_prod_pass }}"
+atom_es_index: "atom_prod"
+```
+
+And the test site variables in `atomsite2.yml`:
+
+```
+atom_path: "/usr/share/nginx/atom-test"
+atom_config_db_name: "atom_test"
+atom_config_db_username: "atomuser_test"
+atom_config_db_password: "{{ vault_atomuser_test_pass }}"
+atom_es_index: "atom_test"
+```
+
+To deploy AtoM dependencies and the first site on the host:
+```
+ansible-playbook playbook-atom.yml -l atomhost -e @sites/atomsite1.yml
+```
+
+Then to deploy the second site:
+```
+ansible-playbook playbook-atom.yml -l atomhost -e @sites/atomsite2.yml -t atom-site
+```
+
+The `-e @<file>` (extra vars) option makes ansible use the variables defined in the 
+specified file in addition to the variables defined in host_vars and the playbook
+(with the values assigned as extra vars taking precedence over assignments
+done elsewhere)
+
+The `-t atom-site` option makes ansible execute only the tasks tagged
+as `atom-site` in the role (i.e., tasks required to deploy a site)
+and skip the tasks that are required only once per host deploy.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,8 @@ atom_devbox: "no"
 #
 
 atom_worker_setup: "yes"
-atom_worker_service_name: "atom-worker"
+# atom worker service name: atom site dir name with "-worker" suffix
+atom_worker_service_name: "{{ atom_path | basename }}-worker"
 # use old config (atom 2.0.x) for atom worker (atom-worker.conf, app.yml)
 # for binder set to "yes"
 atom_worker_old_config: "no"
@@ -158,7 +159,7 @@ atom_es_fields_limit: "3000"
 
 atom_pool_user: "{{ atom_user }}"
 atom_pool_group: "{{ atom_group }}"
-atom_pool_listen: "/var/run/php-fpm.atom.sock"
+atom_pool_listen: "/var/run/php-fpm.{{ atom_path | basename }}.sock"
 atom_pool_listen_allowed_clients: ""
 atom_pool_listen_owner: www-data  # Nginx will use this if it's installed in the same machine
 atom_pool_listen_group: www-data  # Nginx will use this if it's installed in the same machine

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,7 +9,7 @@
 
 - name: "Restart PHP service"
   service:
-    name: "rh-php70-php-fpm"
+    name: "rh-php{{ php_version }}-php-fpm"
     state: "restarted"
   when: ansible_os_family == "RedHat"
 
@@ -22,7 +22,7 @@
 
 - name: "Reload PHP service"
   service:
-    name: "rh-php70-php-fpm"
+    name: "rh-php{{ php_version }}-php-fpm"
     state: "reloaded"
   when: ansible_os_family == "RedHat"
 

--- a/tasks/deps-rh.yml
+++ b/tasks/deps-rh.yml
@@ -44,6 +44,7 @@
     - "gcc"               #
     - "python-pip"        #
     - "python-setuptools" #
+    - "java-1.8.0-openjdk-headless" # needed by FOP
 
 - name: "Upgrade pip"
   pip:

--- a/tasks/fop.yml
+++ b/tasks/fop.yml
@@ -1,50 +1,54 @@
 ---
 
-- name: "Install FOP ( Ubuntu 18.04)"
+- name: "Install FOP package (Ubuntu 18.04)"
   apt:
     pkg: "fop"
     state: "latest"
   when: "ansible_distribution_version is version_compare('18.04', '==')"
   tags:
-    - "fop"
+    - "atom-fop"
 
-- name: "Use FOP 2.1 in AtoM 2.3 or newer (Ubuntu 16.04)"
+- name: "Use FOP 2.1 in AtoM 2.3 or newer (Ubuntu 16.04 or RH)"
   set_fact:
     fop_version: "2.1"
-  tags:
-    - "fop"
-
-- name: "Install Apache FOP: unarchive"
-  unarchive:
-    src: "https://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-{{ fop_version }}-bin.tar.gz"
-    dest: "/usr/share"
-    creates: "/usr/share/fop-{{ fop_version }}"
-    copy: "no"
-    owner: "root"
-    group: "root"
   when: ( ansible_distribution_version is version_compare('16.04', '==') ) or
-        ( ansible_os_family == "RedHat" )
+    ( ansible_os_family == "RedHat" )
   tags:
-    - "fop"
+    - "atom-fop"
 
-- name: "Install Apache FOP: set up FOP_HOME"
-  lineinfile:
-    dest: "/etc/environment"
-    line: "FOP_HOME=/usr/share/fop-{{ fop_version }}"
-  when: ( ansible_distribution_version is version_compare('16.04', '==') ) or
-        ( ansible_os_family == "RedHat" )
+- name: "Use FOP 1.0 in AtoM 2.2 (Ubuntu 14.04)"
+  set_fact:
+    fop_version: "1.0"
+  when: "ansible_distribution_version is version_compare('14.04', '==')"
   tags:
-    - "fop"
+    - "atom-fop"
 
-- name: "Install Apache FOP: symlink"
-  file:
-    src: "/usr/share/fop-{{ fop_version }}/fop"
-    dest: "/usr/local/bin/fop"
-    state: "link"
-  when: ( ansible_distribution_version is version_compare('16.04', '==') ) or
-        ( ansible_os_family == "RedHat" )
+- name: "Install FOP from source (ubuntu <=16.04 or RH)"
+  block:
+    - name: "Install Apache FOP: unarchive (ubuntu <=16.04 or RH)"
+      unarchive:
+        src: "https://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-{{ fop_version }}-bin.tar.gz"
+        dest: "/usr/share"
+        creates: "/usr/share/fop-{{ fop_version }}"
+        copy: "no"
+        owner: "root"
+        group: "root"
+
+    - name: "Install Apache FOP: set up FOP_HOME (ubuntu <=16.04 or RH)"
+      lineinfile:
+        dest: "/etc/environment"
+        line: "FOP_HOME=/usr/share/fop-{{ fop_version }}"
+
+    - name: "Install Apache FOP: symlink (ubuntu <=16.04 or RH)"
+      file:
+        src: "/usr/share/fop-{{ fop_version }}/fop"
+        dest: "/usr/local/bin/fop"
+        state: "link"
+  when: ( ansible_distribution_version is version_compare('16.04', '<=') ) or
+          ( ansible_os_family == "RedHat" )
   tags:
-    - "fop"
+      - "atom-fop"
+
 
 - name: "Allow pdfs to be converted by ImageMagick (Ubuntu)"
   lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,10 @@
 
 - name: "Install AtoM site"
   block:
+    - include: "php-pool-cfg.yml"
+      tags:
+        - "atom-php-pool-cfg"
+
     - include: "basic.yml"
       tags:
         - "atom-basic"
@@ -84,8 +88,9 @@
     - include: "uploads-dir.yml"
       tags:
         - "atom-uploads"
-
   when: atom_install_site|bool == true
+  tags:
+    - "atom-site"
 
 - include: "drmc-mock.yml"
   when: "atom_drmc_mock is defined and atom_drmc_mock|bool"

--- a/tasks/php-pool-cfg.yml
+++ b/tasks/php-pool-cfg.yml
@@ -1,0 +1,55 @@
+---
+
+# we are using the basename of the atom_path to name the pool
+# if atom_path is /usr/share/nginx/atom the pool name is atom, pool config file: atom.conf
+#                 /usr/share/nginx/atom-pub              atom-pub                atom-pub.conf
+- name: "Obtain site name for the php-fpm pool"
+  set_fact:
+    atom_pool_name: "{{ atom_path | basename }}"
+
+- name: "Configure php-fpm pool (Ubuntu 14.04)"
+  block:
+    - name: "Remove default www pool (Ubuntu 14.04)"
+      file:
+        state: "absent"
+        path: "/etc/php{{ php_version }}/fpm/pool.d/www.conf"
+    - name: "Install pool configuration file (Ubuntu 14.04)"
+      template:
+        src: "etc/php{{ php_version }}/fpm/pool.d/atom.conf"
+        dest: "/etc/php/{{ php_version }}/fpm/pool.d/{{ atom_pool_name }}.conf"
+      notify:
+        - "Restart PHP service"
+  when: 
+    - ansible_distribution == "Ubuntu"
+    - "ansible_distribution_version is version_compare('14.04', '==')"
+
+- name: "Configure php-fpm pool (Ubuntu >= 16.04)"
+  block:
+    - name: "Remove default www pool (Ubuntu >= 16.04)"
+      file:
+        state: "absent"
+        path: "/etc/php/{{ php_version }}/fpm/pool.d/www.conf"
+    - name: "Install pool configuration file ( Ubuntu >= 16.04 )"
+      template:
+        src: "etc/php/{{ php_version }}/fpm/pool.d/atom.conf"
+        dest: "/etc/php/{{ php_version }}/fpm/pool.d/{{ atom_pool_name }}.conf"
+      notify:
+        - "Restart PHP service"
+  when: 
+    - "ansible_distribution_version is version_compare('16.04', '>=')"
+    - ansible_distribution == "Ubuntu"
+
+- name: "Configure php-fpm pool (RH)"
+  block:
+    - name: "Remove default www pool"
+      file:
+        state: "absent"
+        path: "/etc/opt/rh/rh-php{{ php_version }}/php-fpm.d/www.conf"
+    - name: "Install pool configuration file"
+      template:
+        src: "etc/php/7.0/fpm/pool.d/atom.conf"
+        dest: "/etc/opt/rh/rh-php{{ php_version }}/php-fpm.d/{{ atom_pool_name }}.conf"
+      notify:
+        - "Restart PHP service"
+  when:
+    - ansible_os_family == "RedHat"

--- a/tasks/php-rh.yml
+++ b/tasks/php-rh.yml
@@ -25,19 +25,6 @@
     dest: "/usr/bin/php"
     state: "link"
 
-- name: "Remove default www pool"
-  file:
-    state: "absent"
-    path: "/etc/opt/rh/rh-php{{ php_version }}/php-fpm.d/www.conf"
-  notify:
-    - "Restart PHP service"
-
-- name: "Install pool configuration file"
-  template:
-    src: "etc/php/7.0/fpm/pool.d/atom.conf"
-    dest: "/etc/opt/rh/rh-php{{ php_version }}/php-fpm.d/atom.conf"
-
-
 - name: "Download memcached module source"
   unarchive: 
     src: "https://github.com/websupport-sk/pecl-memcache/archive/NON_BLOCKING_IO_php7.zip"

--- a/tasks/php.yml
+++ b/tasks/php.yml
@@ -10,34 +10,6 @@
     force: "yes"
   with_items: "{{ php_packages }}"
 
-- name: "Remove default www pool (Ubuntu 14.04)"
-  file:
-    state: "absent"
-    path: "/etc/php{{ php_version }}/fpm/pool.d/www.conf"
-  when: "ansible_distribution_version is version_compare('14.04', '==')"
-  notify:
-    - "Restart PHP service"
-
-- name: "Remove default www pool (Ubuntu >= 16.04)"
-  file:
-    state: "absent"
-    path: "/etc/php/{{ php_version }}/fpm/pool.d/www.conf"
-  when: "ansible_distribution_version is version_compare('16.04', '>=')"
-  notify:
-    - "Restart PHP service"
-
-- name: "Install pool configuration file (Ubuntu 14.04)"
-  template:
-    src: "etc/php{{ php_version }}/fpm/pool.d/atom.conf"
-    dest: "/etc/php/{{ php_version }}/fpm/pool.d/atom.conf"
-  when: "ansible_distribution_version is version_compare('14.04', '==')"
-
-- name: "Install pool configuration file ( Ubuntu >= 16.04 )"
-  template:
-    src: "etc/php/{{ php_version }}/fpm/pool.d/atom.conf"
-    dest: "/etc/php/{{ php_version }}/fpm/pool.d/atom.conf"
-  when: "ansible_distribution_version is version_compare('16.04', '>=')"
-
 # See https://bugs.launchpad.net/ubuntu/+source/php5/+bug/1272788
 - name: "Fix php5-fpm upstart"
   lineinfile:

--- a/tasks/worker.yml
+++ b/tasks/worker.yml
@@ -16,7 +16,7 @@
 - name: "Install atom-worker service (systemd)"
   template:
     src: "lib/systemd/system/atom-worker.service"
-    dest: "/lib/systemd/system/atom-worker.service"
+    dest: "/lib/systemd/system/{{ atom_worker_service_name }}.service"
   when:
     - ansible_service_mgr == "systemd"
 
@@ -30,77 +30,3 @@
     name: "{{ atom_worker_service_name }}"
     state: "restarted"
     enabled: "yes"
-
-#
-# Apache FOP (including installation of Java)
-#
-
-- name: "Install OpenJDK 7 (Ubuntu 14.04)"
-  apt:
-    pkg: "openjdk-7-jre-headless"
-    state: "latest"
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_version is version_compare('14.04', '<=')
-  tags:
-    - "fop"
-
-- name: "Install OpenJDK 8 (Ubuntu 16.04)"
-  apt:
-    pkg: "openjdk-8-jre-headless"
-    state: "latest"
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_version is version_compare('14.04', '>')
-  tags:
-    - "fop"
-
-- name: "Install OpenJDK 8 (RedHat/Centos)"
-  yum:
-    name: "java-1.8.0-openjdk-headless"
-    state: "latest"
-  when:
-    - ansible_os_family == "RedHat"
-  tags:
-    - "fop"
-
-- name: "Use FOP 2.1 in AtoM 2.3 or newer (Ubuntu 16.04)"
-  set_fact:
-    fop_version: "2.1"
-  when: ( ansible_distribution_version is version_compare('16.04', '>=') ) or
-        ( ansible_os_family == "RedHat" )
-  tags:
-    - "fop"
-
-- name: "Use FOP 1.0 in AtoM 2.2 (Ubuntu 14.04)"
-  set_fact:
-    fop_version: "1.0"
-  when: "ansible_distribution_version is version_compare('14.04', '==')"
-  tags:
-    - "fop"
-
-- name: "Install Apache FOP: unarchive"
-  unarchive:
-    src: "https://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-{{ fop_version }}-bin.tar.gz"
-    dest: "/usr/share"
-    creates: "/usr/share/fop-{{ fop_version }}"
-    copy: "no"
-    owner: "root"
-    group: "root"
-  tags:
-    - "fop"
-
-- name: "Install Apache FOP: set up FOP_HOME"
-  lineinfile:
-    dest: "/etc/environment"
-    line: "FOP_HOME=/usr/share/fop-{{ fop_version }}"
-  tags:
-    - "fop"
-
-- name: "Install Apache FOP: symlink"
-  file:
-    src: "/usr/share/fop-{{ fop_version }}/fop"
-    dest: "/usr/local/bin/fop"
-    state: "link"
-  tags:
-    - "fop"

--- a/templates/atom/apps/qubit/config/app.yml
+++ b/templates/atom/apps/qubit/config/app.yml
@@ -7,7 +7,7 @@ all:
   cache_engine: {{ atom_app_cache_engine }}
 {% if atom_app_cache_engine_options is defined %}
   cache_engine_param:
-{% for key, value in atom_app_cache_engine_options.iteritems() %}
+{% for key, value in atom_app_cache_engine_options.items() %}
     {{ key }}: {{ value }}
 {% endfor %}
 {% endif %}

--- a/templates/atom/apps/qubit/config/factories.yml
+++ b/templates/atom/apps/qubit/config/factories.yml
@@ -13,7 +13,7 @@ prod:
       cache:
         class: sfMemcacheCache
         param:
-{% for key, value in atom_app_cache_engine_options.iteritems() %}
+{% for key, value in atom_app_cache_engine_options.items() %}
           {{ key }}: {{ value }}
 {% endfor %}
 {% else %}

--- a/templates/etc/init/atom-worker.conf
+++ b/templates/etc/init/atom-worker.conf
@@ -15,7 +15,7 @@ post-stop exec sleep 3
 env LOCATION={{ atom_path }}
 env LOGFILE={{ atom_path }}/log/worker.log
 # AtoM PHP pool vars 
-{% for key, value in atom_pool_php_envs.iteritems() %}
+{% for key, value in atom_pool_php_envs.items() %}
 {% if value != "" -%}
     env {{ key }}="{{ value }}"
 {% endif %}

--- a/templates/etc/php/5/fpm/pool.d/atom.conf
+++ b/templates/etc/php/5/fpm/pool.d/atom.conf
@@ -1,5 +1,5 @@
 ; Ansible managed file, do not edit directly
-[atom]
+[{{ atom_pool_name }}]
 
 ; The user running the application
 user = {{ atom_pool_user }}

--- a/templates/etc/php/5/fpm/pool.d/atom.conf
+++ b/templates/etc/php/5/fpm/pool.d/atom.conf
@@ -55,7 +55,7 @@ php_admin_value[opcache.validate_timestamps] = {% if atom_environment_type == 'd
 {% endif %}
 
 ; Environment variables
-{% for key, value in atom_pool_php_envs.iteritems() %}
+{% for key, value in atom_pool_php_envs.items() %}
 {% if value != "" -%}
     env[{{ key }}] = "{{ value }}"
 {% endif %}

--- a/templates/etc/php/7.0/fpm/pool.d/atom.conf
+++ b/templates/etc/php/7.0/fpm/pool.d/atom.conf
@@ -59,7 +59,7 @@ php_admin_value[opcache.validate_timestamps] = {% if atom_environment_type == 'd
 {% endif %}
 
 ; Environment variables
-{% for key, value in atom_pool_php_envs.iteritems() %}
+{% for key, value in atom_pool_php_envs.items() %}
 {% if value != "" -%}
     env[{{ key }}] = "{{ value }}"
 {% endif %}

--- a/templates/etc/php/7.0/fpm/pool.d/atom.conf
+++ b/templates/etc/php/7.0/fpm/pool.d/atom.conf
@@ -1,5 +1,5 @@
 ; Ansible managed file, do not edit directly
-[atom]
+[{{ atom_pool_name }}]
 
 ; The user running the application
 user = {{ atom_pool_user }}

--- a/templates/etc/profile.d/atom.sh.j2
+++ b/templates/etc/profile.d/atom.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 # this file managed by ansible
 # AtoM environment variables (required by CLI tools)
-{% for key, value in atom_pool_php_envs.iteritems() %}
+{% for key, value in atom_pool_php_envs.items() %}
 {% if value != "" -%}
 export {{ key }}="{{ value }}"
 {% endif %}

--- a/templates/lib/systemd/system/atom-worker.service
+++ b/templates/lib/systemd/system/atom-worker.service
@@ -34,7 +34,7 @@ RestartSec=30
 #Environment=ATOM_FOO_1=BAR
 #Environment=ATOM_FOO_2=BAR
 # AtoM PHP pool vars 
-{% for key, value in atom_pool_php_envs.iteritems() %}
+{% for key, value in atom_pool_php_envs.items() %}
 {% if value != "" -%}
     Environment={{ key }}="{{ value }}"
 {% endif %}


### PR DESCRIPTION
Fix role to be able to deploy multiple sites on the same host:
- Set atom worker and php pool names based on the basename of atom_path
- Separate host-wide and site-wide php-fpm related tasks
- Clean-up php-fpm restart handlers
- Clean-up FOP installation tasks
- Add README section to explain how to deploy multiple sites

Also replace `iteritems()` with `items()` in template loops, for Python 3 compatibility