### PR TITLE
Add new version to allow overriding default php versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,14 @@ atom_install_dependencies: "true"
 atom_devbox: "no"
 
 #
+# Choose php version to use
+#   - For RH/Centos 70,71,72 and 73 are available. Default is 72
+#   - Ubuntu 14.04 uses php 5, 16.04 7.0 and 18.04 7.2
+#
+# atom_php_version: 72
+#
+
+#
 # Worker
 #
 

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,1 +1,1 @@
-php_version: "72" # Without dots. 70 and 71 are also available
+php_version: "{{ atom_php_version|default('72') }}" # Without dots. 70 and 71 are also available

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,1 +1,1 @@
-php_version: "72" # Without dots. 70 and 71 are also available
+php_version: "{{ atom_php_version|default('72') }}" # Without dots. 70 and 71 are also available

--- a/vars/Ubuntu-14.04.yml
+++ b/vars/Ubuntu-14.04.yml
@@ -1,4 +1,4 @@
-php_version: 5
+php_version: "{{ atom_php_version| default('5') }}"
 php_packages:
   - "php5-cli"
   - "php5-fpm"

--- a/vars/Ubuntu-16.04.yml
+++ b/vars/Ubuntu-16.04.yml
@@ -1,4 +1,4 @@
-php_version: 7.0
+php_version: "{{ atom_php_version|default('7.0') }}"
 php_packages:
   - "php7.0-cli"
   - "php7.0-curl"

--- a/vars/Ubuntu-18.04.yml
+++ b/vars/Ubuntu-18.04.yml
@@ -1,4 +1,4 @@
-php_version: 7.2
+php_version: "{{ atom_php_version|default('7.2') }}"
 php_packages:
   - "php7.2-cli"
   - "php7.2-curl"


### PR DESCRIPTION
This is needed to deploy AtoM using php 7.3 in RedHat/Centos