### PR TITLE
Add support for different password algorithms

### DIFF
--- a/templates/atom/apps/qubit/config/app.yml
+++ b/templates/atom/apps/qubit/config/app.yml
@@ -33,3 +33,6 @@ all:
   # Gearman job server
   gearman_job_server: {{ atom_app_gearman_job_server }}
 {% endif %}
+
+  # Password hash algorithm
+  password_hash_algorithm: {{ password_hash_algorithm|default('PASSWORD_ARGON21') }}


### PR DESCRIPTION
PASSWORD_ARGON21 is not supported in Xenial nor RHEL 7