### PR TITLE
app.yml: password_hash_algorithm fixes

### DIFF
--- a/templates/atom/apps/qubit/config/app.yml
+++ b/templates/atom/apps/qubit/config/app.yml
@@ -34,5 +34,7 @@ all:
   gearman_job_server: {{ atom_app_gearman_job_server }}
 {% endif %}
 
+{% if atom_app_password_hash_algorithm is defined %}
   # Password hash algorithm
-  password_hash_algorithm: {{ password_hash_algorithm|default('PASSWORD_ARGON21') }}
+  password_hash_algorithm: {{ atom_app_password_hash_algorithm }}
+{% endif %}


### PR DESCRIPTION
- Rename ansible variable to follow role convention (add atom_app_
  prefix)
- Add password_hash_algorithm to app.yml only if ansible variable
  is defined
- Remove default (not required to add to apps/qubit/config/app.yml as
  config/app.yml has already it defined) (also the value used has a
  typo)