### PR TITLE
Add npm dependency libssl1.0-dev

### DIFF
--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -51,6 +51,7 @@
     - "poppler-utils"     #
     - "ffmpeg"            #
     - "git"               # ↓ Build dependencies
+    - "libssl1.0-dev"     #
     - "npm"               #
     - "make"              #
     - "python-pip"        #


### PR DESCRIPTION
The npm package is now dependent on the libssl1.0-dev package.
Adding libssl to be installed as a dependency when Ubuntu 18.04.