### PR TITLE
Fix SELinux tasks with atom_revision_directory

### DIFF
--- a/tasks/basic.yml
+++ b/tasks/basic.yml
@@ -139,8 +139,12 @@
 
 - name: "SELinux tasks"
   block:
-    - name: "Selinux: allow httpd to write on atom folder"
+    - name: "Selinux: allow httpd to write on atom folder (when using atom_revision_directory)"
       shell: 'semanage fcontext -a -t httpd_sys_rw_content_t {{ atom_path }}/{{ atom_extra_path }}\(/.*\)? && restorecon -R -v {{ atom_path }}/{{ atom_extra_path }}'
+      when: atom_revision_directory|bool
+    - name: "Selinux: allow httpd to write on atom folder (when not using atom_revision_directory)"
+      shell: 'semanage fcontext -a -t httpd_sys_rw_content_t {{ atom_path }}\(/.*\)? && restorecon -R -v {{ atom_path }}'
+      when: not atom_revision_directory|bool
     - name: "Selinux: allow httpd to write on uploads folders"
       shell: 'semanage fcontext -a -t httpd_sys_rw_content_t {{ atom_uploads_symlink }}\(/.*\)? && restorecon -R -v {{ atom_uploads_symlink }}'
       when:


### PR DESCRIPTION
This PR fixes a bug with atom_revision_directory=False and SELinux. Adding a
conditional to avoid running the commands in {{ atom_atom_path }}/ directory
instead of {{ atom_path }} (without final slash)

Connects to #67 