### PR TITLE
Add auto init functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ playbook structure won't work.  E.g. Changing the "atom/config/config.php"
 to "myatom/config/config.php" will load a template file at that relative
 path in your playbook directory structure.
 
+## Automatic database initialization
+
+**Use with caution! This feature is experimental.**
+
+If `atom_auto_init` is enabled, this role will initialize the database using
+`tools:purge` as long as the uninitialized criteria is met.
+
+We discourage to use this feature unless you are deploying temporary
+environments such as those used in camps, demos or QA environments. In the long
+term, AtoM may provide a CLI installer with safer guarantees that we could use
+in this role.
+
 ## Deploy multiple sites on the same host
 
 To deploy multiple AtoM sites on the same host, it is possible to have

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,10 @@ atom_upgrade_sql: "no"
 # Misc
 #
 
+# Automatic initialization
+# EXPERIMENTAL - DO NOT USE IN PRODUCTION ENVIRONMENTS.
+atom_auto_init: "no"
+
 # Flush database
 atom_flush_data: "no"
 

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -1,0 +1,55 @@
+---
+
+# The goal of the tasks in this file is to determine whether AtoM needs to be
+# initialized. The inconvenience is that the current mechanism to initialize
+# the database is the same used to flush an existing database.
+
+- name: "Look up database contents 1/2"
+  check_mode: "no"
+  changed_when: False
+  register: "db_information_object_exists"
+  command: >
+    mysql \
+      --user={{ atom_config_db_username }} \
+      --password={{ atom_config_db_password }} \
+      --host={{ atom_config_db_hostname }} \
+      --port={{ atom_config_db_port }} \
+      --skip-column-names \
+      --execute="SHOW TABLES LIKE 'information_object';" \
+        {{ atom_config_db_name }}
+  ignore_errors: true
+  failed_when: false
+
+- name: "Look up database contents 2/2"
+  check_mode: "no"
+  changed_when: False
+  register: "db_lookup"
+  command: >
+    mysql \
+      --user={{ atom_config_db_username }} \
+      --password={{ atom_config_db_password }} \
+      --host={{ atom_config_db_hostname }} \
+      --port={{ atom_config_db_port }} \
+      --skip-column-names \
+      --execute="SELECT COUNT(*) FROM information_object WHERE id = 1;" \
+        {{ atom_config_db_name }}
+  ignore_errors: true
+  failed_when: false
+
+- name: "Create uninitialized fact"
+  set_fact:
+    uninitialized: False
+
+- name: "Determine if flush/init is needed 1/2"
+  set_fact:
+    uninitialized: True
+  when:
+    - "db_information_object_exists.rc == 0"
+    - "db_information_object_exists.stdout_lines == []"
+
+- name: "Determine if flush/init is needed 2/2"
+  set_fact:
+    uninitialized: True
+  when:
+    - "db_lookup.rc == 0"
+    - "db_lookup.stdout_lines == ['0']"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,12 +88,18 @@
       tags:
         - "atom-basic"
 
+    - include: "init.yml"
+      when:
+        - "atom_auto_init is defined and atom_auto_init|bool"
+      tags:
+        - "atom-site"
+
     - include: "flush.yml"
       become_user: "{{ atom_user }}"
       environment:
         - "{{ atom_pool_php_envs }}"
         - PATH: "{{ ansible_env.PATH }}:/opt/rh/rh-php{{ php_version }}/root/bin/"
-      when: "atom_flush_data is defined and atom_flush_data|bool"
+      when: "uninitialized or (atom_flush_data is defined and atom_flush_data|bool)"
       tags:
         - "atom-flush"
 


### PR DESCRIPTION
This pull request introduces an experimental solution to auto-initialize AtoM installations using `tools:purge`. In the absence of a proper installer, this can be convenient in some scenarios like setting up camps, but it is generally discouraged when data loss is not affordable.

When `atom_auto_init` is enabled (feature flag), a new include `init.yml` tries to determine whether `tools:purge` should be executed. It does so by looking up the application database finding a clue of previous initialization state. The absence of the root information object is what triggers initialization, while its existence or any access error during the look up will not.

Connects to https://github.com/artefactual-labs/ansible-atom/issues/71.