### PR TITLE
Install dev-related packages from atom_devbox.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ an arrangement as follows:
 |-- playbook-atom.yml      => AtoM deployment playbook
 |-- ansible.cfg
 |-- hosts
-|-- ... 
+|-- ...
 ```
 
 Where `atomsite1.yml`, `atomsite2.yml`, ... define role variables that
-need to be different for site1, site2,... 
+need to be different for site1, site2,...
 
-As a minimum, the variable `atom_path` must be different for each site. 
-The basename of `atom_path` is used to create identifiers that need to be 
+As a minimum, the variable `atom_path` must be different for each site.
+The basename of `atom_path` is used to create identifiers that need to be
 different for each site, such as php pool and worker names (the basename
-is the last component of the path, e.g., if `atom_path` is 
+is the last component of the path, e.g., if `atom_path` is
 "/usr/share/nginx/atom" then the basename is "atom")
 
-For example, if deploying AtoM production and test sites, we could 
+For example, if deploying AtoM production and test sites, we could
 define the production site variables in `atomsite1.yml`:
 
 ```
@@ -103,7 +103,7 @@ Then to deploy the second site:
 ansible-playbook playbook-atom.yml -l atomhost -e @sites/atomsite2.yml -t atom-site
 ```
 
-The `-e @<file>` (extra vars) option makes ansible use the variables defined in the 
+The `-e @<file>` (extra vars) option makes ansible use the variables defined in the
 specified file in addition to the variables defined in host_vars and the playbook
 (with the values assigned as extra vars taking precedence over assignments
 done elsewhere)
@@ -133,3 +133,17 @@ For instance:
 ├── src -> /usr/share/nginx/atom/atom-381f849b6ecd763dedf92a7bad43cc350a3c5439
 └── uploads
 ```
+
+## Development box
+
+This role is also used to set up our [Vagrant box](vagrantbox) for development
+purposes, including workflows where code changes and documentation work is
+required.
+
+The role variable that controls this behaviour is `atom_devbox` (boolean).
+However, this is only known to work in the context of Vagrant and our build
+system based on [Packer](packer), e.g. it assumes that the `vagrant` user has
+been previously created.
+
+vagrantbox: https://www.accesstomemory.org/en/docs/latest/dev-manual/env/vagrant/
+packer: https://github.com/artefactual-labs/am-packbuild/tree/qa/1.x/packer/templates

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,8 @@ atom_repository_version: "stable/2.4.x"
 atom_install_site: "true"
 atom_install_dependencies: "true"
 # Install some extra packages specific to our official Vagrant-based
-# development box. See `tasks/devbox.yml` for more details.
+# development box. See `tasks/devbox.yml` for more details. It is only
+# compatible with Vagrant machines.
 atom_devbox: "no"
 # Use a different AtoM directory for each revision
 atom_revision_directory: "no"

--- a/tasks/deps-rh.yml
+++ b/tasks/deps-rh.yml
@@ -40,23 +40,7 @@
       - "rh-nodejs6"                  #
       - "make"                        #
       - "gcc"                         #
-      - "python-pip"                  #
-      - "python-setuptools"           #
       - "java-1.8.0-openjdk-headless" # needed by FOP
-    state: "latest"
-
-- name: "Upgrade pip"
-  pip:
-    name: "pip"
-    state: "present"
-    version: "20.3"
-
-- name: "Install Sphinx"
-  pip:
-    name:
-      - "sphinx"
-      - "sphinxcontrib-httpdomain"
-      - "sphinx_rtd_theme"
     state: "latest"
 
 # don't quote the shell command, or it won't work (also need to escape the <)

--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -34,8 +34,6 @@
       - "git"                    # ↓ Build dependencies
       - "nodejs"                 #
       - "make"                   #
-      - "python-pip"             #
-      - "python-setuptools"      #
       - "openjdk-8-jre-headless" # Needed by FOP
     state: "latest"
   when: "ansible_distribution_version is version('16.04', '<=')"
@@ -51,8 +49,6 @@
       - "libssl1.0-dev"          #
       - "npm"                    #
       - "make"                   #
-      - "python-pip"             #
-      - "python-setuptools"      #
       - "openjdk-8-jre-headless" # Needed by FOP
     state: "latest"
   when: "ansible_distribution_version is version_compare('18.04', '==')"
@@ -67,20 +63,9 @@
       - "git"                    # ↓ Build dependencies
       - "npm"                    #
       - "make"                   #
-      - "python-is-python3"      #
-      - "python3-pip"            #
-      - "python-setuptools"      #
       - "openjdk-8-jre-headless" # Needed by FOP
     state: "latest"
   when: "ansible_distribution_version is version_compare('20.04', '>=')"
-
-- name: "Install Sphinx"
-  pip:
-    name:
-      - "sphinx"
-      - "sphinxcontrib-httpdomain"
-      - "sphinx_rtd_theme"
-    state: "latest"
 
 - name: "Install npm global dependencies (also required during the build)"
   npm:

--- a/tasks/devbox.yml
+++ b/tasks/devbox.yml
@@ -85,6 +85,21 @@
     accept_hostkey: "yes"
   become_user: "vagrant"
 
+- name: "Install packages"
+  package:
+    name: "{{ devbox_packages }}"
+    state: "present"
+
+- name: "Upgrade pip"
+  pip:
+    name: "pip"
+    state: "present"
+    version: "20.3"
+
+- name: "Install atom-docs requirements"
+  pip:
+    requirements: "{{ ansible_env.HOME }}/atom-docs/requirements.txt"
+
 - name: "Create symlink to AtoM sources"
   file:
     src: "/usr/share/nginx/atom"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -147,6 +147,8 @@
     - "drmc-mock"
 
 - include: "devbox.yml"
-  when: "atom_devbox|bool"
+  when:
+    - "atom_devbox|bool"
+    - "ansible_distribution == 'Ubuntu'"
   tags:
     - "atom-devbox"

--- a/vars/Ubuntu-14.04.yml
+++ b/vars/Ubuntu-14.04.yml
@@ -9,3 +9,7 @@ php_packages:
   - "php5-ldap"
   - "php5-memcache"
   - "php5-apcu"
+
+devbox_packages:
+  - "python-pip"
+  - "python-setuptools"

--- a/vars/Ubuntu-16.04.yml
+++ b/vars/Ubuntu-16.04.yml
@@ -17,3 +17,6 @@ php_packages:
   - "php-memcache"
   - "php-apcu"
 
+devbox_packages:
+  - "python-pip"
+  - "python-setuptools"

--- a/vars/Ubuntu-18.04.yml
+++ b/vars/Ubuntu-18.04.yml
@@ -17,3 +17,6 @@ php_packages:
   - "php-memcache"
   - "php-apcu"
 
+devbox_packages:
+  - "python-pip"
+  - "python-setuptools"

--- a/vars/Ubuntu-20.04.yml
+++ b/vars/Ubuntu-20.04.yml
@@ -15,3 +15,8 @@ php_packages:
   - "php7.4-zip"
   - "php-memcache"
   - "php-apcu"
+
+devbox_packages:
+  - "python-is-python3"
+  - "python3-pip"
+  - "python-setuptools"


### PR DESCRIPTION
This commit adds a new list of packages (`devbox_packages`) meant to be
installed only when targeting the development box. This is to avoid
installing dev-related packages in production environments.

Sphinx-related requirements are pulled from `atom-docs/requirements.txt`.

Connects to https://github.com/artefactual-labs/ansible-atom/issues/78.