### PR TITLE
Manage installation of Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,12 @@ been previously created.
 
 vagrantbox: https://www.accesstomemory.org/en/docs/latest/dev-manual/env/vagrant/
 packer: https://github.com/artefactual-labs/am-packbuild/tree/qa/1.x/packer/templates
+
+## License
+
+AGPL-3.0.
+
+Composer management based on [Ansible Role: Composer] (Jeff Geerling, MIT).
+
+
+[Ansible Role: Composer]: https://github.com/geerlingguy/ansible-role-composer

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,13 @@
       when:
         - ansible_os_family == "RedHat"
 
+    - include: "php-composer.yml"
+      environment:
+        - PATH: "{{ ansible_env.PATH }}:/opt/rh/rh-php{{ php_version }}/root/bin/"
+      tags:
+        - "atom-php"
+        - "atom-php-composer"
+
     - include: "fop.yml"
       environment:
         - PATH: "{{ ansible_env.PATH }}:/opt/rh/rh-php{{ php_version }}/root/bin/"

--- a/tasks/php-composer.yml
+++ b/tasks/php-composer.yml
@@ -1,0 +1,56 @@
+# Based on geerlingguy/ansible-role-composer (MIT):
+# https://github.com/geerlingguy/ansible-role-composer
+
+- name: Check if Composer is installed.
+  stat: "path={{ composer_path }}"
+  register: composer_bin
+
+- name: Get Composer installer signature.
+  uri:
+    url: https://composer.github.io/installer.sig
+    return_content: true
+  register: composer_installer_signature
+  when: not composer_bin.stat.exists
+
+- name: Download Composer installer.
+  get_url:
+    url: https://getcomposer.org/installer
+    dest: /tmp/composer-installer.php
+    mode: 0755
+    checksum: "sha384:{{ composer_installer_signature.content }}"
+  when: not composer_bin.stat.exists
+
+- name: Run Composer installer.
+  command: >
+    php composer-installer.php {% if composer_version_branch %} {{ composer_version_branch }}{% elif composer_version %} --version={{ composer_version }}{% endif %}
+    chdir=/tmp
+  when: not composer_bin.stat.exists
+
+- name: Move Composer into globally-accessible location.
+  command: >
+    mv /tmp/composer.phar {{ composer_path }}
+    creates={{ composer_path }}
+  when: not composer_bin.stat.exists
+
+- name: Update Composer to latest version (if configured).
+  command: >
+    php {{ composer_path }} self-update {{ composer_version_branch }}
+  register: composer_update
+  changed_when: "'Updating to version' in composer_update.stdout"
+  when: composer_keep_updated | bool
+
+- name: Ensure composer directory exists.
+  become: true
+  become_user: "{{ composer_home_owner }}"
+  file:
+    path: "{{ composer_home_path }}"
+    owner: "{{ composer_home_owner }}"
+    group: "{{ composer_home_group }}"
+    state: directory
+    mode: 0755
+
+- name: Add composer_home_path bin directory to global $PATH.
+  template:
+    src: etc/profile.d/composer.sh.j2
+    dest: /etc/profile.d/composer.sh
+    mode: 0644

--- a/templates/etc/profile.d/composer.sh.j2
+++ b/templates/etc/profile.d/composer.sh.j2
@@ -1,0 +1,1 @@
+export PATH=$PATH:{{ composer_home_path }}/vendor/bin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,8 @@
+---
+composer_path: "/usr/local/bin/composer"
+composer_home_path: "~/.composer"
+composer_home_owner: "root"
+composer_home_group: "root"
+composer_keep_updated: false
+composer_version: ""
+composer_version_branch: '--2'


### PR DESCRIPTION
This pull request updates this role in order to manage the installation of Composer, designed to happen once PHP is installed. It is based on [geerlingguy/ansible-role-composer](https://github.com/geerlingguy/ansible-role-composer). Long term, we're considering to adopt third-party roles to manage the installation of PHP, Composer, etc.

I've tested this pull request in various ways, e.g. it should not break playbooks where geerlingguy/ansible-role-composer is already a dependency, but it's preferably to update them. We're planning to do so in deploy-pub.

Connects to https://github.com/artefactual-labs/ansible-atom/issues/80.