### PR TITLE
Check atom_environment_type to add dev packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,10 +12,6 @@ atom_repository_url: "https://github.com/artefactual/atom.git"
 atom_repository_version: "stable/2.4.x"
 atom_install_site: "true"
 atom_install_dependencies: "true"
-# Install some extra packages specific to our official Vagrant-based
-# development box. See `tasks/devbox.yml` for more details. It is only
-# compatible with Vagrant machines.
-atom_devbox: "no"
 # Use a different AtoM directory for each revision
 atom_revision_directory: "no"
 atom_revision_directory_latest_symlink_dir: "src"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -155,7 +155,7 @@
 
 - include: "devbox.yml"
   when:
-    - "atom_devbox|bool"
+    - "atom_environment_type == 'development'"
     - "ansible_distribution == 'Ubuntu'"
   tags:
     - "atom-devbox"


### PR DESCRIPTION
Removes atom_devbox variable support in favor of atom_environment_type.

Refs #85.