### PR TITLE
Fix default app.yml cache settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,13 +120,20 @@ atom_template_propel_ini: "atom/config/propel.ini"
 
 atom_template_app_yml: "atom/apps/qubit/config/app.yml"
 atom_app_upload_limit: "-1"
+
+## app.yml cache settings (prefix must be different for each site in a multisite deploy)
 atom_app_cache_engine: "sfMemcacheCache"
 atom_app_cache_engine_options:
   storeCacheInfo: "yes"
-  prefix: "atom"
+  prefix: "{{ atom_path | basename }}"
   host: "127.0.0.1"
   port: "11211"
   persistent: "yes"
+## if not using memcached, replace with:
+# atom_app_cache_engine: "sfAPCCache"
+# atom_app_cache_engine_options:
+#   prefix: "{{ atom_path | basename }}"
+
 # atom_app_google_maps_api_key:
 # atom_app_google_analytics_api_key:
 # atom_app_google_analytics_institutions_dimension_index:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -121,7 +121,13 @@ atom_template_propel_ini: "atom/config/propel.ini"
 atom_template_app_yml: "atom/apps/qubit/config/app.yml"
 atom_app_upload_limit: "-1"
 
-## app.yml cache settings (prefix must be different for each site in a multisite deploy)
+## app.yml cache settings:
+## - If using memcached, set host and port according to your setup
+##   (the host and port settings below are for memcached running
+##   locally on the default port)
+## - If the cache is shared among multiple AtoM instances, make sure
+##   that the prefix is different for each instance (the prefix setting
+##   below works if the multiple atom instances are on the same server)
 atom_app_cache_engine: "sfMemcacheCache"
 atom_app_cache_engine_options:
   storeCacheInfo: "yes"
@@ -129,7 +135,7 @@ atom_app_cache_engine_options:
   host: "127.0.0.1"
   port: "11211"
   persistent: "yes"
-## if not using memcached, replace with:
+## if not using memcached, replace for example with:
 # atom_app_cache_engine: "sfAPCCache"
 # atom_app_cache_engine_options:
 #   prefix: "{{ atom_path | basename }}"


### PR DESCRIPTION
- Set cache prefix based on atom_path (to be different per site in a
  multisite deployment)
- Add example settings for when using sfAPCCache