### PR TITLE
move SELinux tasks for symlink to their taskfile

### DIFF
--- a/tasks/basic.yml
+++ b/tasks/basic.yml
@@ -145,14 +145,6 @@
     - name: "Selinux: allow httpd to write on atom folder (when not using atom_revision_directory)"
       shell: 'semanage fcontext -a -t httpd_sys_rw_content_t {{ atom_path }}\(/.*\)? && restorecon -R -v {{ atom_path }}'
       when: not atom_revision_directory|bool
-    - name: "Selinux: allow httpd to write on uploads folders"
-      shell: 'semanage fcontext -a -t httpd_sys_rw_content_t {{ atom_uploads_symlink }}\(/.*\)? && restorecon -R -v {{ atom_uploads_symlink }}'
-      when:
-        - "atom_uploads_symlink is defined"
-    - name: "Selinux: allow httpd to write on downloads folders"
-      shell: 'semanage fcontext -a -t httpd_sys_rw_content_t {{ atom_downloads_symlink }}\(/.*\)? && restorecon -R -v {{ atom_downloads_symlink }}'
-      when:
-        - "atom_downloads_symlink is defined"
     - name: "Selinux: enable httpd_can_network_connect"
       seboolean:
         name: httpd_can_network_connect

--- a/tasks/symlink-dirs.yml
+++ b/tasks/symlink-dirs.yml
@@ -77,3 +77,19 @@
     owner: "{{ atom_user }}"
     group: "{{ atom_group }}"
   when: "atom_downloads_symlink is undefined"
+
+- name: "SELinux tasks for symlinks"
+  block:
+    - name: "Selinux: allow httpd to write on uploads folders"
+      shell: 'semanage fcontext -a -t httpd_sys_rw_content_t {{ atom_uploads_symlink }}\(/.*\)? && restorecon -R -v {{ atom_uploads_symlink }}'
+      when:
+        - "atom_uploads_symlink is defined"
+    - name: "Selinux: allow httpd to write on downloads folders"
+      shell: 'semanage fcontext -a -t httpd_sys_rw_content_t {{ atom_downloads_symlink }}\(/.*\)? && restorecon -R -v {{ atom_downloads_symlink }}'
+      when:
+        - "atom_downloads_symlink is defined"
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+  tags:
+    - selinux


### PR DESCRIPTION
The symlink directories SELinux tasks ve been be moved to the
`tasks/symlink-dirs.yml` task file just after creating the directories.

Connects to https://github.com/artefactual-labs/ansible-atom/issues/90