### PR TITLE
Allow CSRF protection configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,9 @@ atom_revision_directory_latest_symlink_dir: "src"
 # Create a symlink from atom_path/private to
 # atom_path/atom_revision_directory_latest_symlink_dir
 atom_private_symlink: "no"
+# CSRF protection should be enabled in 2.7.x and higher
+# but it must be disabled in 2.6.x and lower.
+atom_csrf_protection: "no"
 
 #
 # Choose php version to use

--- a/tasks/basic.yml
+++ b/tasks/basic.yml
@@ -69,6 +69,12 @@
     group: "{{ atom_group }}"
     mode: "u=rwx,g=rwx,o=rx"
 
+- name: "Generate CSRF secret"
+  vars:
+    secret: "{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}"
+  set_fact:
+    atom_csrf_secret: "{{ secret if atom_csrf_protection|bool else 'false' }}"
+
 - name: "Install configuration files"
   template:
     src: "{{ item.src }}"

--- a/templates/atom/apps/qubit/config/settings.yml
+++ b/templates/atom/apps/qubit/config/settings.yml
@@ -35,7 +35,7 @@ test:
 all:
   .settings:
     # Form security secret (CSRF protection)
-    csrf_secret:            false
+    csrf_secret:            {{ atom_csrf_secret }}
 
     enabled_modules:        [default, aclGroup]
 


### PR DESCRIPTION
Add a new variable to enable or disable CSRF protection to, based
on its boolean value, set the `csrf_secret` setting to `false` or an
auto-generated string (32 charts, digits and ASCII letters).