### PR TITLE
2.6.4?

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ atom_user: "www-data"
 atom_group: "www-data"
 atom_path: "/usr/share/nginx/atom"
 atom_repository_url: "https://github.com/artefactual/atom.git"
-atom_repository_version: "stable/2.4.x"
+atom_repository_version: "stable/2.6.x"
 atom_install_site: "true"
 atom_install_dependencies: "true"
 # Use a different AtoM directory for each revision

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,7 +182,7 @@ atom_app_gearman_job_server: "127.0.0.1:4730"
 #   Atom 2.1, Binder 0.8: "2.1"
 #   Atom 2.4: "2.4"
 #   Atom 2.5, Binder 0.9: "2.5"
-atom_es_config_version: "2.4"
+atom_es_config_version: "2.6"
 atom_template_search_yml: "atom/apps/qubit/config/{{ atom_es_config_version }}-search.yml"
 
 atom_es_host: "127.0.0.1"


### PR DESCRIPTION
I recently ran a playbook that has ansible-atom as a role and noticed that when it finished I had an AtoM instance that displayed that I needed to upgrade at the top. Is it ok to update the role to 2.6.4?

Also, does the role handle upgrades, migrations etc, that need to be run to update my instance? Thanks for any information you can provide.