### PR TITLE
pool-fpm template: Add pm.process_idle_timeout var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -211,6 +211,7 @@ atom_pool_listen_owner: www-data  # Nginx will use this if it's installed in the
 atom_pool_listen_group: www-data  # Nginx will use this if it's installed in the same machine
 atom_pool_listen_mode: "0600"
 atom_pool_pm: "dynamic"
+atom_pool_pm_process_idle_timeout: "10s" # Only used with pm=ondemand, not used on dynamic or static
 atom_pool_pm_max_children: "30"
 atom_pool_pm_start_servers: "10"
 atom_pool_pm_min_spare_servers: "10"

--- a/templates/etc/php/7.0/fpm/pool.d/atom.conf
+++ b/templates/etc/php/7.0/fpm/pool.d/atom.conf
@@ -13,6 +13,9 @@ listen.mode = {{ atom_pool_listen_mode }}
 
 ; The following directives should be tweaked based in your hardware resources
 pm = {{ atom_pool_pm }}
+{% if atom_pool_pm == "ondemand" %}
+pm.process_idle_timeout = {{ atom_pool_pm_process_idle_timeout }}
+{% endif %}
 pm.max_children = {{ atom_pool_pm_max_children }}
 pm.start_servers = {{ atom_pool_pm_start_servers }}
 pm.min_spare_servers = {{ atom_pool_pm_min_spare_servers }}


### PR DESCRIPTION
The `pm.process_control_timeout` variable is needed when using the
ondemand pm.

Connects to #113 