### PR TITLE
defauts: set atom_pool_php_upload_max_filesize

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -220,7 +220,7 @@ atom_pool_pm_max_requests: "200"
 atom_pool_php_memory_limit: "512M"
 atom_pool_php_max_execution_time: "120"
 atom_pool_php_post_max_size: "72M"
-atom_pool_php_upload_max_filesize: "64M"
+atom_pool_php_upload_max_filesize: "{{ atom_pool_php_upload_max_filesize | default('64M') }}"
 atom_pool_php_envs:
   ATOM_DEBUG_IP: "127.0.0.1"
   ATOM_READ_ONLY: "{% if atom_app_read_only|bool %}on{% else %}off{% endif %}"


### PR DESCRIPTION
updated atom_pool_php_upload_max_filesize so it can be set in host_vars