### PR TITLE
Use java 11 on AtoM 2.7 and improve CentOS 2.7 upgrade

### DIFF
--- a/tasks/deps-rh-php-74.yml
+++ b/tasks/deps-rh-php-74.yml
@@ -57,6 +57,17 @@
       - "nodejs"
     state: "latest"
 
+- name: "Check if exists an old lessc symlink"
+  stat:
+    path: "/usr/bin/lessc"
+  register: _lessc_symlink
+
+- name: "Remove old lessc symlink"
+  file:
+    path: "/usr/bin/lessc"
+    state: "absent"
+  when: _lessc_symlink.stat.islnk is defined and _lessc_symlink.stat.islnk
+
 - name: "Install npm global dependencies (also required during the build)"
   npm:
     name: "{{ item }}"

--- a/tasks/deps-rh-php-74.yml
+++ b/tasks/deps-rh-php-74.yml
@@ -47,7 +47,7 @@
       - "git"                         # ↓ Build dependencies
       - "make"                        #
       - "gcc"                         #
-      - "java-1.8.0-openjdk-headless" # needed by FOP
+      - "java-11-openjdk-headless"    # needed by FOP
       - "Judy-devel"                  # needed by memprof
     state: "latest"
 

--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -69,15 +69,15 @@
 - name: "Install AtoM dependencies (Ubuntu >= Focal/20.04)"
   apt:
     pkg:
-      - "imagemagick"            # ↓ AtoM dependencies
-      - "ghostscript"            #
-      - "poppler-utils"          #
-      - "ffmpeg"                 #
-      - "git"                    # ↓ Build dependencies
-      - "nodejs"                 #
-      - "make"                   #
-      - "openjdk-8-jre-headless" # Needed by FOP
-      - "libjudy-dev"            # Needed by memprof
+      - "imagemagick"             # ↓ AtoM dependencies
+      - "ghostscript"             #
+      - "poppler-utils"           #
+      - "ffmpeg"                  #
+      - "git"                     # ↓ Build dependencies
+      - "nodejs"                  #
+      - "make"                    #
+      - "openjdk-11-jre-headless" # Needed by FOP
+      - "libjudy-dev"             # Needed by memprof
     state: "latest"
   when: "ansible_distribution_version is version_compare('20.04', '>=')"
 

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,4 +1,4 @@
 php_version: "{{ atom_php_version|default('72') }}" # Without dots. 70, 71, 73 and 74 are also available
-php_service_name: "{% if atom_php_version|int < 74 %}rh-php{{ php_version }}-php-fpm{% else %}php{{ php_version }}-php-fpm{% endif %}"
-php_rh_centos_path: "{% if atom_php_version|int < 74 %}/opt/rh/rh-php{{ php_version }}/root/bin{% else %}/opt/remi/php{{ php_version }}/root/bin{% endif %}"
-php_rh_centos_etc_path: "{% if atom_php_version|int < 74 %}/etc/opt/rh/rh-php{{ php_version }}{% else %}/etc/opt/remi/php{{ php_version }}{% endif %}"
+php_service_name: "{% if php_version|int < 74 %}rh-php{{ php_version }}-php-fpm{% else %}php{{ php_version }}-php-fpm{% endif %}"
+php_rh_centos_path: "{% if php_version|int < 74 %}/opt/rh/rh-php{{ php_version }}/root/bin{% else %}/opt/remi/php{{ php_version }}/root/bin{% endif %}"
+php_rh_centos_etc_path: "{% if php_version|int < 74 %}/etc/opt/rh/rh-php{{ php_version }}{% else %}/etc/opt/remi/php{{ php_version }}{% endif %}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,4 @@
 php_version: "{{ atom_php_version|default('72') }}" # Without dots. 70 and 71 are also available
-php_service_name: "{% if atom_php_version|int < 74 %}rh-php{{ php_version }}-php-fpm{% else %}php{{ php_version }}-php-fpm{% endif %}"
-php_rh_centos_path: "{% if atom_php_version|int < 74 %}/opt/rh/rh-php{{ php_version }}/root/bin{% else %}/opt/remi/php{{ php_version }}/root/bin{% endif %}"
-php_rh_centos_etc_path: "{% if atom_php_version|int < 74 %}/etc/opt/rh/rh-php{{ php_version }}{% else %}/etc/opt/remi/php{{ php_version }}{% endif %}"
+php_service_name: "{% if php_version|int < 74 %}rh-php{{ php_version }}-php-fpm{% else %}php{{ php_version }}-php-fpm{% endif %}"
+php_rh_centos_path: "{% if php_version|int < 74 %}/opt/rh/rh-php{{ php_version }}/root/bin{% else %}/opt/remi/php{{ php_version }}/root/bin{% endif %}"
+php_rh_centos_etc_path: "{% if php_version|int < 74 %}/etc/opt/rh/rh-php{{ php_version }}{% else %}/etc/opt/remi/php{{ php_version }}{% endif %}"


### PR DESCRIPTION
AtoM 2.7 requires java 11, as you can see here:

https://www.accesstomemory.org/en/docs/2.7/admin-manual/installation/ubuntu/

And this morning I found small issues when upgrading on RHEL.