### PR TITLE
build: Use a different task to clean npm cache

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -110,7 +110,20 @@
       loop:
         - ".config"
         - ".npm"
-    - name: "Clean cache, install and build with npm on AtoM site directory"
+    # Sometimes 'npm cache clean' fails. Ignoring errors
+    # See: https://github.com/artefactual-labs/ansible-atom/issues/119
+    - name: "Clean cache npm on AtoM site directory"
+      become: "yes"
+      become_user: "{{ atom_user }}"
+      command: "npm cache clean --force"
+      args:
+        chdir: "{{ atom_path }}/{{ atom_extra_path }}"
+      failed_when: false
+      changed_when: false
+      check_mode: false
+      environment:
+        CYPRESS_INSTALL_BINARY: 0
+    - name: "Install and build with npm on AtoM site directory"
       become: "yes"
       become_user: "{{ atom_user }}"
       command: "{{ item }}"
@@ -119,7 +132,6 @@
       environment:
         CYPRESS_INSTALL_BINARY: 0
       loop:
-        - "npm cache clean --force"
         - "npm install"
         - "npm run build"
   when:


### PR DESCRIPTION
Sometimes the NPM clear cache fails with:

```
STDERR:
npm WARN using --force Recommended protections disabled.
npm ERR! code ENOTEMPTY
npm ERR! syscall rmdir
npm ERR! path /var/www/.npm/_cacache
npm ERR! errno -39
npm ERR! ENOTEMPTY: directory not empty, rmdir '/var/www/.npm/_cacache'
```

But the next npm tasks are working fine.

This commit creates a new separate task (that ignores errors) to clear the cache.

Connects to:

 https://github.com/artefactual-labs/ansible-atom/issues/119