### PR TITLE
npm: Pin version to latest 9 version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -279,3 +279,9 @@ atom_worker_systemd_success_exit_status: "111"
 #
 
 atom_php_install_memprof_module: "no"
+
+#
+# NPM
+#
+
+atom_npm_version: "9.8.1"

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -91,8 +91,8 @@
 
 - name: "Prepare npm to be used with bootstrap5 themes"
   block:
-    - name: "Update npm to latest version of its release"
-      command: "npm install -g npm@latest"
+    - name: "Update npm to {{ atom_npm_version }} version"
+      command: "npm install -g npm@{{ atom_npm_version }}"
     - name: "Get AtoM user home directory"
       become_user: "{{ atom_user }}"
       become: "yes"


### PR DESCRIPTION
We were upgrading to latest npm version always, but npm 10.0.0 has been released and it doesn't support node 14-16.

This commit allows to select the desired version with the new variable:

* `atom_npm_version`

This variable has been set with a default value of "9.8.1", that is the latest version 9 right now.