### PR TITLE
Never add PATH to profile.d/atom.sh

### DIFF
--- a/templates/etc/profile.d/atom.sh.j2
+++ b/templates/etc/profile.d/atom.sh.j2
@@ -1,8 +1,9 @@
 #!/bin/bash
 # this file managed by ansible
 # AtoM environment variables (required by CLI tools)
+# Not adding PATH or null env vars
 {% for key, value in atom_pool_php_envs.items() %}
-{% if value != "" -%}
+{% if key != "PATH" and value != "" -%}
 export {{ key }}="{{ value }}"
 {% endif %}
 {% endfor %}
@@ -11,3 +12,4 @@ export {{ key }}="{{ value }}"
 # enable SCLs for node and php
 source scl_source enable rh-nodejs6 rh-php{{ php_version }}
 {% endif %}
+


### PR DESCRIPTION
To use pdfinfo, convert, and other CLI tools on RHEL/Rocky 9, the PATH variable must be defined in the PHP-FPM pool config. However, this role was also injecting all environment variables from `atom_pool_php_envs` into:

  /etc/profile.d/atom.sh

As a result, the PATH variable was being overridden system-wide, which is undesirable — especially since PHP-FPM pools don't allow expressions like PATH=$PATH:/custom/bin.

This commit updates the `templates/etc/profile.d/atom.sh.j2` template to skip the PATH variable when generating the profile script.