### PR TITLE
Add PASSWORD_ARGON2I RHEL/Rocky support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -167,6 +167,17 @@ atom_app_cache_engine_options:
 # atom_app_google_tag_manager_container_id:
 # atom_app_csv_transform_script_name:
 
+# Define password_hash_algorithm. More info: https://www.php.net/manual/en/function.password-hash.php
+# The recommended value is PASSWORD_ARGON2I (more secure), but old RHEL/CentOS database can have BCRYPT hash, so setting default RHEL value to BCRYPT
+# RHEL/Rocky support for PASSWORD_ARGON2I only added recently for php remi packages and AtoM > 2.7 (via php-sodium package)
+atom_app_password_hash_algorithm: "{{ 'PASSWORD_BCRYPT' if ansible_os_family in ['RedHat', 'Rocky'] else 'PASSWORD_ARGON2I' }}"
+
+# Install php-sodium package in EL9. Requires AtoM > 2.7
+# In case you want to use PASSWORD_ARGON2I in EL9, you need to set:
+# 1) atom_rh_install_php_sodium_package: True
+# 2) atom_app_password_hash_algorithm: 'PASSWORD_ARGON2I'
+atom_rh_install_php_sodium_package: False
+
 #
 # factories.yml
 #
@@ -216,7 +227,7 @@ atom_es_batch_size: "500"
 atom_es_fields_limit: "3000"
 
 #
-# php5-fpm pool
+# php-fpm pool
 #
 
 atom_pool_user: "{{ atom_user }}"

--- a/tasks/php-rh-74.yml
+++ b/tasks/php-rh-74.yml
@@ -19,6 +19,13 @@
       - "java-1.8.0-openjdk-headless" # needed for fop
     state: "latest"
 
+- name: "Install php-sodium package"
+  yum:
+    name:
+      - "php{{ php_version }}-php-sodium" # needed for PASSWORD_ARGON2I password algorithm
+    state: "latest"
+  when: "atom_rh_install_php_sodium_package|bool"
+
 - name: "Remove existing /usr/bin/php"
   file:
     path: "/usr/bin/php"

--- a/tasks/php-rh-8.yml
+++ b/tasks/php-rh-8.yml
@@ -26,6 +26,16 @@
     install_weak_deps: false
     state: "latest"
 
+
+- name: "Install php-sodium package"
+  yum:
+    name:
+      - "php{{ php_version }}-php-sodium" # needed for PASSWORD_ARGON2I password algorithm
+    allowerasing: true
+    install_weak_deps: false
+    state: "latest"
+  when: "atom_rh_install_php_sodium_package|bool"
+
 - name: "Create /usr/bin/php link"
   file:
     src: "{{ php_rh_centos_path }}/php"


### PR DESCRIPTION
Add php-sodium package for password hashes.

Only added for php>=7.4 (AtoM >= 2.7)

For old deployments compatibility, the default value has been set as PASSWORD_BCRYPT for RHEL/Rocky, but it can be redefined with the `atom_app_password_hash_algorithm` role var.

Added new var to install php-sodium package (Default false):

*` atom_rh_install_php_sodium_package`

Connects to https://github.com/artefactual-labs/ansible-atom/issues/132