### PR TITLE
Add 2.10 search settings template

### DIFF
--- a/templates/atom/apps/qubit/config/2.10-search.yml
+++ b/templates/atom/apps/qubit/config/2.10-search.yml
@@ -1,0 +1,258 @@
+# Ansible managed file, do not edit directly
+
+all:
+
+  # See http://www.elasticsearch.org/guide/reference/api/bulk.html
+  batch_mode: true
+  batch_size: {{ atom_es_batch_size }}
+
+  # Elastica API options
+  # Full list of available options:
+  # https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Client.php#L39
+  server:
+
+    # Server defaults to localhost:9200 if omitted
+    # It can also be used to configure a cluster of ElasticSearch nodes
+    # See more info at: http://ruflin.github.com/Elastica/
+    host: {{ atom_es_host }}
+    port: {{ atom_es_port }}
+
+    # This will write the JSON request in the file given
+    # log: '/tmp/elastica.log'
+
+  # elasticsearch options
+  index:
+
+    # This is the name of the index; must be unique
+    name: {{ atom_es_index }}
+
+    # List of settings: http://goo.gl/EjQx4
+    configuration:
+
+      settings:
+        number_of_shards: 4
+        number_of_replicas: 1
+        mapping.total_fields.limit: {{ atom_es_fields_limit }}
+
+        analysis:
+
+          analyzer:
+            default:
+              tokenizer: standard
+              filter: [lowercase, preserved_asciifolding]
+
+            # This is a special analyzer for autocomplete searches. It's used only
+            # in some fields as it can make the index very big.
+            autocomplete:
+              tokenizer: whitespace
+              filter: [lowercase, engram, preserved_asciifolding]
+
+            arabic:
+              tokenizer: standard
+              filter: [lowercase, arabic_stop, preserved_asciifolding]
+            armenian:
+              tokenizer: standard
+              filter: [lowercase, armenian_stop, preserved_asciifolding]
+            basque:
+              tokenizer: standard
+              filter: [lowercase, basque_stop, preserved_asciifolding]
+            brazilian:
+              tokenizer: standard
+              filter: [lowercase, brazilian_stop, preserved_asciifolding]
+            bulgarian:
+              tokenizer: standard
+              filter: [lowercase, bulgarian_stop, preserved_asciifolding]
+            catalan:
+              tokenizer: standard
+              filter: [lowercase, catalan_stop, preserved_asciifolding]
+            czech:
+              tokenizer: standard
+              filter: [lowercase, czech_stop, preserved_asciifolding]
+            danish:
+              tokenizer: standard
+              filter: [lowercase, danish_stop, preserved_asciifolding]
+            dutch:
+              tokenizer: standard
+              filter: [lowercase, dutch_stop, preserved_asciifolding]
+            english:
+              tokenizer: standard
+              filter: [lowercase, english_stop, preserved_asciifolding]
+            finnish:
+              tokenizer: standard
+              filter: [lowercase, finnish_stop, preserved_asciifolding]
+            french:
+              tokenizer: standard
+              filter: [lowercase, french_stop, preserved_asciifolding, french_elision]
+            galician:
+              tokenizer: standard
+              filter: [lowercase, galician_stop, preserved_asciifolding]
+            german:
+              tokenizer: standard
+              filter: [lowercase, german_stop, preserved_asciifolding]
+            greek:
+              tokenizer: standard
+              filter: [lowercase, greek_stop, preserved_asciifolding]
+            hindi:
+              tokenizer: standard
+              filter: [lowercase, hindi_stop, preserved_asciifolding]
+            hungarian:
+              tokenizer: standard
+              filter: [lowercase, hungarian_stop, preserved_asciifolding]
+            indonesian:
+              tokenizer: standard
+              filter: [lowercase, indonesian_stop, preserved_asciifolding]
+            italian:
+              tokenizer: standard
+              filter: [lowercase, italian_stop, preserved_asciifolding]
+            norwegian:
+              tokenizer: standard
+              filter: [lowercase, norwegian_stop, preserved_asciifolding]
+            persian:
+              tokenizer: standard
+              filter: [lowercase, persian_stop, preserved_asciifolding]
+            portuguese:
+              tokenizer: standard
+              filter: [lowercase, portuguese_stop, preserved_asciifolding]
+            romanian:
+              tokenizer: standard
+              filter: [lowercase, romanian_stop, preserved_asciifolding]
+            russian:
+              tokenizer: standard
+              filter: [lowercase, russian_stop, preserved_asciifolding]
+            spanish:
+              tokenizer: standard
+              filter: [lowercase, spanish_stop, preserved_asciifolding]
+            swedish:
+              tokenizer: standard
+              filter: [lowercase, swedish_stop, preserved_asciifolding]
+            turkish:
+              tokenizer: standard
+              filter: [lowercase, turkish_stop, preserved_asciifolding]
+
+          normalizer:
+            # Custom normalizer that lowercases text, removes punctation, and
+            # does ascii folding for more natural alphabetic sorting
+            alphasort:
+              type: custom
+              filter: [lowercase, asciifolding]
+              char_filter: [punctuation_filter]
+
+          filter:
+            engram:
+              type: edge_ngram
+              min_gram: 3
+              max_gram: 10
+            french_elision:
+              type: elision
+              articles: [l, m, t, qu, n, s, j, d, c, jusqu, quoiqu, lorsqu, puisqu]
+            preserved_asciifolding:
+              type: asciifolding
+              preserve_original: true
+
+            # To make 'stopwords' works with other token filters the analyzers can't have
+            # standard type and the 'stopwords' needs to be added as a token filter too
+            arabic_stop:
+              type: stop
+              stopwords: _arabic_
+            armenian_stop:
+              type: stop
+              stopwords: _armenian_
+            basque_stop:
+              type: stop
+              stopwords: _basque_
+            brazilian_stop:
+              type: stop
+              stopwords: _brazilian_
+            bulgarian_stop:
+              type: stop
+              stopwords: _bulgarian_
+            catalan_stop:
+              type: stop
+              stopwords: _catalan_
+            czech_stop:
+              type: stop
+              stopwords: _czech_
+            danish_stop:
+              type: stop
+              stopwords: _danish_
+            dutch_stop:
+              type: stop
+              stopwords: _dutch_
+            english_stop:
+              type: stop
+              stopwords: _english_
+            finnish_stop:
+              type: stop
+              stopwords: _finnish_
+            french_stop:
+              type: stop
+              stopwords: _french_
+            galician_stop:
+              type: stop
+              stopwords: _galician_
+            german_stop:
+              type: stop
+              stopwords: _german_
+            greek_stop:
+              type: stop
+              stopwords: _greek_
+            hindi_stop:
+              type: stop
+              stopwords: _hindi_
+            hungarian_stop:
+              type: stop
+              stopwords: _hungarian_
+            indonesian_stop:
+              type: stop
+              stopwords: _indonesian_
+            italian_stop:
+              type: stop
+              stopwords: _italian_
+            norwegian_stop:
+              type: stop
+              stopwords: _norwegian_
+            persian_stop:
+              type: stop
+              stopwords: _persian_
+            portuguese_stop:
+              type: stop
+              stopwords: _portuguese_
+            romanian_stop:
+              type: stop
+              stopwords: _romanian_
+            russian_stop:
+              type: stop
+              stopwords: _russian_
+            spanish_stop:
+              type: stop
+              stopwords: _spanish_
+            swedish_stop:
+              type: stop
+              stopwords: _swedish_
+            turkish_stop:
+              type: stop
+              stopwords: _turkish_
+
+          char_filter:
+
+            # This char_filter is added to all analyzers when the index
+            # is created in arElasticSearchPlugin initialize when the
+            # app_markdown_enabled setting is set to true. Ideally, the
+            # Markdown tags should be removed with several regex like
+            # in this example: https://github.com/stiang/remove-markdown.
+            # But processing all those regex could run very slowly, so
+            # we're replacing the following punctuation chars by spaces:
+            #     *_#![]()->`+\~:|^=
+            strip_md:
+              type: pattern_replace
+              pattern: '[\*_#!\[\]\(\)\->`\+\\~:\|\^=]'
+              replacement: ' '
+
+            # Strip punctation from a string
+            punctuation_filter:
+              type: pattern_replace
+              pattern: '["''_\-\?!\.\(\)\[\]#\*`:;]'
+              replacement: ''
+
+      # Module settings:
+      # http://www.elasticsearch.org/guide/reference/index-modules/


### PR DESCRIPTION
This sets the current [search.yml](https://github.com/artefactual/atom/blob/ba52c4e2cf38fb4bd2899a4c9e07ad109f5a34aa/plugins/arElasticSearchPlugin/config/search.yml) configuration file from AtoM's `qa/2.x` branch as a new `2.10-search.yml` template (adjusting the `atom_*` variables).