### PR TITLE
factories: Configure session cookie in template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -185,6 +185,9 @@ atom_rh_install_php_sodium_package: False
 atom_template_factories_yml: "atom/apps/qubit/config/factories.yml"
 atom_factory_user: "myUser" # e.g. adLdapUser
 atom_factory_user_timeout: "1800"
+atom_factory_session_cookie_name: "symfony"
+atom_factory_session_cookie_httponly: true
+atom_factory_session_cookie_secure: false
 
 #
 # settings.yml

--- a/templates/atom/apps/qubit/config/factories.yml
+++ b/templates/atom/apps/qubit/config/factories.yml
@@ -7,9 +7,9 @@ prod:
 {% if atom_app_cache_engine == "sfMemcacheCache" or atom_app_cache_engine == "sfAPCCache" %}
     class: QubitCacheSessionStorage
     param:
-      session_name: symfony
-      session_cookie_httponly: true
-      session_cookie_secure: false
+      session_name: {{ atom_factory_session_cookie_name | default('symfony') }}
+      session_cookie_httponly: {{ atom_factory_session_cookie_httponly | default('true') }}
+      session_cookie_secure: {{ atom_factory_session_cookie_secure | default('false') }}
       cache:
         class: {{ atom_app_cache_engine }}
         param:
@@ -19,9 +19,9 @@ prod:
 {% else %}
     class: QubitSessionStorage
     param:
-      session_name: symfony
-      session_cookie_httponly: true
-      session_cookie_secure: false
+      session_name: {{ atom_factory_session_cookie_name | default('symfony') }}
+      session_cookie_httponly: {{ atom_factory_session_cookie_httponly | default('true') }}
+      session_cookie_secure: {{ atom_factory_session_cookie_secure | default('false') }}
 {% endif %}
 
 test:


### PR DESCRIPTION
This commit allows to define the following values for the session cookie in the facties.yml config file:

* cookie name
* cookie http only (boolean)
* cookie secure (boolean)