### PR TITLE
Allow to change theme on db upgrade

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,10 @@ atom_fix_data: "no"
 # Upgrade sql
 atom_upgrade_sql: "no"
 
+#Useful when upgrading to AtoM >= 2.10 from AtoM <= 2.9 and existing theme is BS2. To avoid the input of selecting new supported Themes. Only applies when atom_upgrade_sql=yes
+atom_upgrade_sql_enable_theme: False
+atom_upgrade_sql_theme: "arDominionB5Plugin"
+
 #
 # Misc
 #

--- a/tasks/cli_tools.yml
+++ b/tasks/cli_tools.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: "Change theme before database upgrade"
+  command: "php symfony tools:atom-plugins add {{ atom_upgrade_sql_theme }}"
+  args:
+    chdir: "{{ atom_path }}/{{ atom_extra_path }}"
+  when:
+    - atom_upgrade_sql_enable_theme|bool
+    - atom_upgrade_sql_theme is defined
+    - atom_upgrade_sql|bool
+
 - name: "Update database"
   command: "php symfony tools:upgrade-sql -B"
   args:


### PR DESCRIPTION
Added two new variables to define the theme to use before upgrading the database.

Useful when upgrading to AtoM >= 2.10 from AtoM <= 2.9 and existing theme is BS2 (to avoid the input of selecting new supported Themes). Only applies when atom_upgrade_sql=yes

Variables added and default values:

```
atom_upgrade_sql_enable_theme: False
atom_upgrade_sql_theme: "arDominionB5Plugin"
```