### PR TITLE
stop atom-worker in upgrades

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,8 @@ atom_csrf_protection: "no"
 #
 
 atom_worker_setup: "yes"
+# Stop the worker before deploy when the worker service already exists.
+atom_worker_stop_before_deploy: "yes"
 # atom worker service name: atom site dir name with "-worker" suffix
 atom_worker_service_name: "{{ atom_path | basename }}-worker"
 # use old config (atom 2.0.x) for atom worker (atom-worker.conf, app.yml)
@@ -383,4 +385,3 @@ atom_npm_version: >-
       "9.8.1"
     ) | trim
   }}
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,6 +120,12 @@
     - "atom-worker"
     - "drmc-mock"
 
+- import_tasks: "worker-stop.yml"
+  when: "atom_worker_setup is defined and atom_worker_setup|bool"
+  tags:
+    - "atom-worker"
+    - "atom-site"
+
 - name: "Install AtoM site"
   block:
     - import_tasks: "php-pool-cfg.yml"

--- a/tasks/worker-stop.yml
+++ b/tasks/worker-stop.yml
@@ -1,0 +1,19 @@
+---
+
+- name: "Check whether atom-worker service exists"
+  stat:
+    path: "{{ item }}"
+  loop:
+    - "/lib/systemd/system/{{ atom_worker_service_name }}.service"
+    - "/etc/init/{{ atom_worker_service_name }}.conf"
+  register: atom_worker_service_files
+  changed_when: false
+
+- name: "Stop worker before deploy"
+  service:
+    name: "{{ atom_worker_service_name }}"
+    state: "stopped"
+  ignore_errors: true
+  when:
+    - atom_worker_stop_before_deploy|bool
+    - atom_worker_service_files.results | selectattr('stat.exists') | list | length > 0


### PR DESCRIPTION
When upgrading AtoM, if a bot runs a export it can create a file in the downloads directory before creating the symlink and makes the role fails.

And probably is not a good idea having the worker running jobs when upgrading.